### PR TITLE
docs: add architecture, oracle, security, and roadmap docs (#108, #109)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,102 @@
+# Architecture Overview
+
+smile4money is a trustless chess wagering platform built on Stellar Soroban smart contracts. This document describes the system components and how they interact.
+
+## Components
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Players                              │
+│              (Stellar wallets / frontend)                   │
+└────────────────────┬────────────────────────────────────────┘
+                     │ create_match / deposit / cancel_match
+                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│                  Escrow Contract                            │
+│                                                             │
+│  • Holds XLM / USDC stakes in persistent storage           │
+│  • Manages match lifecycle (Pending → Active → Completed)  │
+│  • Executes payouts on verified result                      │
+│  • Admin pause / unpause controls                          │
+└────────────────────┬────────────────────────────────────────┘
+                     │ submit_result (oracle address only)
+                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│                  Oracle Contract                            │
+│                                                             │
+│  • Stores verified match results on-chain                  │
+│  • Admin-gated: only the oracle service can write          │
+│  • Emits events for off-chain indexers                     │
+└────────────────────┬────────────────────────────────────────┘
+                     │ polls game APIs
+                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│              Off-chain Oracle Service                       │
+│                                                             │
+│  • Watches Lichess / Chess.com APIs for game results       │
+│  • Submits verified results to the Oracle Contract         │
+│  • Calls submit_result on the Escrow Contract to pay out   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Match Lifecycle
+
+```
+create_match()
+     │
+     ▼
+  Pending ──── deposit(player1) ──── deposit(player2) ──── Active
+     │                                                        │
+     └── cancel_match() ──── Cancelled          submit_result()
+                                                              │
+                                                         Completed
+```
+
+1. **Pending** — Match created, awaiting both deposits. Either player can cancel.
+2. **Active** — Both players have deposited. Game is in progress. Cannot be cancelled.
+3. **Completed** — Oracle submitted result, payout executed.
+4. **Cancelled** — Cancelled before activation; any deposits refunded.
+
+## Contracts
+
+### Escrow Contract (`contracts/escrow`)
+
+The core contract. Responsibilities:
+
+- `initialize(oracle, admin)` — Sets the trusted oracle address and admin. One-time call.
+- `create_match(player1, player2, stake_amount, token, game_id, platform)` — Creates a match record in persistent storage.
+- `deposit(match_id, player)` — Transfers `stake_amount` tokens from the player to the contract. Transitions to `Active` when both players have deposited.
+- `submit_result(match_id, winner, caller)` — Oracle-only. Executes payout to winner (or splits on draw) and marks match `Completed`.
+- `cancel_match(match_id, caller)` — Either player can cancel a `Pending` match. Refunds any deposits.
+- `pause()` / `unpause()` — Admin-only emergency controls.
+
+### Oracle Contract (`contracts/oracle`)
+
+A lightweight result registry. Responsibilities:
+
+- `initialize(admin)` — Sets the oracle service address. One-time call.
+- `submit_result(match_id, game_id, result)` — Admin-only. Stores a `ResultEntry` keyed by `match_id`.
+- `get_result(match_id)` — Returns the stored `ResultEntry`.
+- `has_result(match_id)` — Returns whether a result exists.
+
+## Storage
+
+Both contracts use Soroban **persistent storage** for match and result data, with TTL extended to `MATCH_TTL_LEDGERS` (~30 days at 5s/ledger) on every write. Instance storage holds contract-level config (oracle address, admin, match count, paused flag).
+
+## Token Support
+
+The escrow contract is token-agnostic — it accepts any SEP-41 compatible token address. v1.0 targets XLM; v1.1 adds USDC.
+
+## Events
+
+All state transitions emit on-chain events for off-chain indexers and frontends:
+
+| Contract | Event topic          | Data                              |
+|----------|----------------------|-----------------------------------|
+| Escrow   | `match / created`    | `(match_id, player1, player2, stake_amount)` |
+| Escrow   | `match / activated`  | `match_id`                        |
+| Escrow   | `match / completed`  | `(match_id, winner)`              |
+| Escrow   | `match / cancelled`  | `match_id`                        |
+| Escrow   | `admin / paused`     | `()`                              |
+| Escrow   | `admin / unpaused`   | `()`                              |
+| Oracle   | `oracle / result`    | `(match_id, result)`              |

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -1,0 +1,91 @@
+# Oracle Design
+
+The oracle is the bridge between off-chain chess game results and the on-chain escrow contract. This document describes how it works, its trust model, and its failure modes.
+
+## Overview
+
+smile4money uses a two-layer oracle design:
+
+1. **Oracle Contract** (`contracts/oracle`) — An on-chain result registry. Stores verified results keyed by `match_id`. Admin-gated so only the trusted oracle service can write.
+2. **Off-chain Oracle Service** — A backend process that polls Lichess and Chess.com APIs, verifies game outcomes, and submits results to both the Oracle Contract and the Escrow Contract.
+
+## Data Flow
+
+```
+Chess.com / Lichess API
+         │
+         │  GET /game/{game_id}
+         ▼
+  Off-chain Oracle Service
+         │
+         ├── submit_result(match_id, game_id, result)  ──▶  Oracle Contract
+         │                                                   (stores result on-chain)
+         │
+         └── submit_result(match_id, winner, caller)   ──▶  Escrow Contract
+                                                            (executes payout)
+```
+
+## Oracle Contract API
+
+### `initialize(admin: Address)`
+
+Sets the oracle service address. Can only be called once — subsequent calls panic.
+
+### `submit_result(match_id: u64, game_id: String, result: MatchResult) -> Result<(), Error>`
+
+Stores a verified result on-chain. Requires admin auth. Rejects duplicate submissions (`Error::AlreadySubmitted`). Emits an `oracle / result` event.
+
+`MatchResult` variants:
+- `Player1Wins`
+- `Player2Wins`
+- `Draw`
+
+### `get_result(match_id: u64) -> Result<ResultEntry, Error>`
+
+Returns the stored `ResultEntry` for a match, or `Error::ResultNotFound`.
+
+### `has_result(match_id: u64) -> bool`
+
+Returns `true` if a result has been submitted for the given match ID.
+
+## Off-chain Oracle Service
+
+The oracle service is responsible for:
+
+1. **Watching** — Polling Lichess (`/api/game/{id}`) and Chess.com (`/pub/player/{user}/games/{yyyy}/{mm}`) for game completion.
+2. **Verifying** — Confirming the game is finished and mapping the result to the correct `match_id` stored in the escrow contract.
+3. **Submitting** — Calling `submit_result` on the Oracle Contract (for auditability) and `submit_result` on the Escrow Contract (to trigger payout).
+
+### Environment Variables
+
+```env
+LICHESS_API_TOKEN=<your-lichess-api-token>
+CHESSDOTCOM_API_KEY=<your-chessdotcom-api-key>
+CONTRACT_ORACLE=<oracle-contract-id>
+CONTRACT_ESCROW=<escrow-contract-id>
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+```
+
+## Trust Model
+
+The oracle is the only address authorized to call `submit_result` on the Escrow Contract. This means:
+
+- If the oracle service is compromised, it can submit incorrect results and redirect payouts.
+- The oracle address can be rotated via `update_oracle(new_oracle)` on the Escrow Contract (admin-only).
+- All oracle submissions are recorded on-chain and emit events, making any manipulation auditable.
+
+## Failure Modes
+
+| Scenario | Behaviour |
+|---|---|
+| Oracle service goes offline | Match stays `Active` indefinitely. Players can wait or the admin can intervene. |
+| Oracle submits wrong `match_id` | Escrow rejects if match is not `Active`. Oracle contract records the result regardless. |
+| Duplicate result submission | Oracle contract returns `Error::AlreadySubmitted` and rejects. |
+| Oracle key compromised | Admin rotates oracle address via `update_oracle`. Existing completed matches are unaffected. |
+
+## Platforms Supported
+
+| Platform | API | `Platform` enum value |
+|---|---|---|
+| Lichess | `https://lichess.org/api/game/{id}` | `Platform::Lichess` |
+| Chess.com | `https://api.chess.com/pub/...` | `Platform::ChessDotCom` |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,41 @@
+# Roadmap
+
+## v1.0 — Current
+
+Core escrow and oracle functionality on Stellar Soroban.
+
+- XLM-only escrow contract
+- Lichess Oracle integration
+- Basic match flow: create → deposit → result → payout
+- Draw handling (stakes returned to both players)
+- Admin pause / unpause controls
+- On-chain events for all state transitions
+- GitHub Actions CI (cargo test + cargo build --target wasm32)
+
+## v1.1 — Multi-token & Chess.com
+
+- USDC support (and any SEP-41 token)
+- Chess.com Oracle integration
+- Oracle address rotation (`update_oracle` admin function)
+- Timeout-based cancellation: player2 can cancel after a configurable ledger timeout if player1 never deposits
+
+## v2.0 — Tournaments
+
+- Multi-game tournament brackets
+- Bracket payout contract: distributes prize pool across rounds
+- Tournament admin: create bracket, seed players, advance rounds
+- On-chain bracket state and results
+
+## v3.0 — Frontend
+
+- Web UI with Stellar wallet integration (Freighter, xBull)
+- Match creation and deposit flow in-browser
+- Live match status and payout history
+- Off-chain indexer for event streaming
+
+## v4.0 — Mobile & Matchmaking
+
+- Mobile app (iOS / Android)
+- ELO-based matchmaking: pair players of similar rating
+- Leaderboards: on-chain ranking by winnings and win rate
+- Push notifications for match events

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,106 @@
+# Threat Model & Security
+
+This document describes the security properties of smile4money, known trust assumptions, and mitigations in place.
+
+## Trust Assumptions
+
+| Actor | Trusted for | Mitigation if compromised |
+|---|---|---|
+| Oracle service | Submitting correct game results | Admin can rotate oracle address via `update_oracle` |
+| Admin address | Pausing contract, rotating oracle | Admin key should be a multisig or hardware wallet |
+| Stellar network | Transaction finality and ordering | Inherent to the platform; no mitigation needed |
+| Token contract | Correct SEP-41 transfer behaviour | Use only audited, well-known token contracts |
+
+## Access Control
+
+### Escrow Contract
+
+| Function | Who can call |
+|---|---|
+| `initialize` | Anyone (once only — panics on second call) |
+| `create_match` | `player1` (requires auth) |
+| `deposit` | `player1` or `player2` (requires auth) |
+| `submit_result` | Registered oracle address only |
+| `cancel_match` | `player1` or `player2` (requires auth) |
+| `pause` / `unpause` | Admin only |
+
+### Oracle Contract
+
+| Function | Who can call |
+|---|---|
+| `initialize` | Anyone (once only — panics on second call) |
+| `submit_result` | Admin (oracle service) only |
+| `get_result` / `has_result` | Anyone (read-only) |
+
+## Known Risks & Mitigations
+
+### Oracle Compromise
+
+**Risk**: A compromised oracle can submit incorrect results and redirect payouts.
+
+**Mitigations**:
+- All oracle submissions emit on-chain events, making manipulation auditable.
+- Admin can rotate the oracle address without redeploying.
+- Oracle contract records all results independently for cross-referencing.
+
+### Re-initialization
+
+**Risk**: An attacker calls `initialize` again to overwrite the oracle or admin address.
+
+**Mitigation**: Both contracts check for existing storage keys on `initialize` and panic if already set.
+
+### Self-match
+
+**Risk**: A single address creates a match against itself to cycle funds.
+
+**Mitigation**: `create_match` rejects `player1 == player2` with `Error::InvalidPlayers`.
+
+**Note**: `InvalidPlayers` is documented as a planned guard — verify it is enforced in the current contract version.
+
+### Duplicate Game ID
+
+**Risk**: The same chess game ID is used across multiple matches, allowing the oracle to pay out multiple times for one game.
+
+**Mitigation**: `create_match` tracks used `game_id` values and rejects duplicates.
+
+**Note**: Verify `DataKey::GameId` uniqueness tracking is implemented in the current version.
+
+### Zero-stake Match
+
+**Risk**: Matches created with `stake_amount = 0` waste ledger storage.
+
+**Mitigation**: `create_match` returns `Error::InvalidAmount` if `stake_amount <= 0`.
+
+### Storage Expiry
+
+**Risk**: Soroban persistent storage entries expire after their TTL. Expired match records cause `MatchNotFound` errors for active matches.
+
+**Mitigation**: Every persistent write calls `extend_ttl` with `MATCH_TTL_LEDGERS` (~30 days). The oracle service should re-extend TTL for long-running matches.
+
+### Player2 Fund Lock
+
+**Risk**: If player1 abandons a match after player2 has deposited, player2's funds are locked.
+
+**Mitigation**: Either player can cancel a `Pending` match. Player2 can cancel and recover their deposit at any time before the match becomes `Active`.
+
+### Integer Overflow
+
+**Risk**: `MatchCount` wraps silently in release mode.
+
+**Mitigation**: `checked_add(1)` is used when incrementing `MatchCount`, returning `Error::Overflow` on overflow.
+
+### Contract Pause
+
+**Risk**: A critical vulnerability is discovered post-deployment.
+
+**Mitigation**: Admin can call `pause()` to block `create_match`, `deposit`, and `submit_result`. Existing completed matches are unaffected.
+
+## What Is Not Covered
+
+- **Frontend security** — The frontend is out of scope for v1.0. Wallet interactions should follow Stellar wallet security best practices.
+- **Oracle service key management** — The oracle private key must be stored securely (e.g., HSM or secrets manager). This is an operational concern.
+- **Stellar network-level attacks** — Sequence number manipulation, fee bumping, and similar Stellar-level concerns are outside the scope of the smart contracts.
+
+## Reporting Vulnerabilities
+
+If you discover a security issue, please open a private GitHub issue or contact the maintainers directly before public disclosure.


### PR DESCRIPTION
closes #108 
closes #109 

Changes                                                                                        
                                                                                                 
  docs/architecture.md                                                                           
                                                                                                 
  - ASCII component diagram showing the full system: Players → Escrow Contract → Oracle Contract 
  → Off-chain Oracle Service → Chess APIs                                                        
  - Match lifecycle state machine: Pending → Active → Completed / Cancelled with the triggering  
  function at each transition                                                                    
  - Per-contract responsibility breakdown covering all public functions                          
  - Storage model explanation (persistent vs instance, TTL strategy)                             
  - Complete events reference table mapping every emitted event to its topic and data payload    
                                                                                                 
  docs/oracle.md                                                                                 
                                                                                                 
  - Data flow diagram showing how the off-chain service bridges chess APIs to both the Oracle    
  Contract and the Escrow Contract                                                               
  - Full Oracle Contract API reference with function signatures, auth requirements, error codes, 
  and event emissions                                                                            
  - Off-chain oracle service responsibilities: watching, verifying, and submitting results       
  - Required environment variables for the oracle service                                        
  - Trust model: what the oracle is trusted for and what happens if it's compromised             
  - Failure mode table covering oracle downtime, wrong match ID, duplicate submission, and key   
  compromise                                                                                     
                                                                                                 
  docs/security.md                                                                               
                                                                                                 
  - Trust assumptions table: oracle service, admin address, Stellar network, token contract —    
  with mitigation for each                                                                       
  - Access control tables for both Escrow and Oracle contracts listing every function and who is 
  authorized to call it                                                                          
  - Detailed risk entries for: oracle compromise, re-initialization attack, self-match, duplicate
  game ID, zero-stake match, storage expiry, player2 fund lock, integer overflow, and contract   
  pause                                                                                          
  - Out-of-scope section (frontend security, oracle key management, Stellar network-level        
  - Vulnerability reporting guidance                                                             
                                                                                                 
  docs/roadmap.md                                                                                
                                                                                                 
  - v1.0 (current): core escrow, Lichess oracle, XLM-only, CI                                    
  - v1.1: USDC/SEP-41 token support, Chess.com oracle, oracle rotation, timeout-based            
  - v2.0: tournament brackets, bracket payout contract, on-chain bracket state                   
  - v3.0: web frontend with wallet integration, off-chain event indexer                          
  - v4.0: mobile app, ELO-based matchmaking, leaderboards, push notifications                    
                                                                                                 
  ───────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                 
  Testing                                                                                        
                                                                                                 
  No code changes — documentation only. All content was derived directly from the implemented    
  contract source (contracts/escrow/src/lib.rs, contracts/oracle/src/lib.rs) to ensure accuracy. 
                   