### PR TITLE
infra: add clippy job and CI badge (#120)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,31 @@ jobs:
       - name: Run tests
         run: cargo test
 
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: clippy
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
   build:
     name: Build WASM
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # smile4money — Competitive Chess Betting on Stellar
 
+[![CI](https://github.com/obajecollinsmicheal-cmd/smile4money/actions/workflows/ci.yml/badge.svg)](https://github.com/obajecollinsmicheal-cmd/smile4money/actions/workflows/ci.yml)
+
 A trustless chess wagering platform built on Stellar Soroban smart contracts. Players stake XLM or USDC before a match, and the winner is automatically paid out the moment the game ends — no middleman, no delays, no trust required.
 
 ## 🎯 What is smile4money?


### PR DESCRIPTION
                                                                                                                             
  Closes #120                                                                                    
                                                                                                 
  Changes                                                                                        
                                                                                                 
  - `.github/workflows/ci.yml` — added a clippy job that runs cargo clippy -- -D warnings on     
  every PR and push to main/master, with cargo dependency caching                                
  - `README.md` — added CI status badge linked to the workflow                                   
                                                                                                 
  What the CI pipeline now covers                                                                
                                                                                                 
  ┌──────────┬───────────┬─────────────────────────────────────┐                                 
  │ Job      │ Trigger   │ Purpose                                                 │             
  ├──────────┼──────────────┼─────────────────────────────────────────────────────────┤          
  │ `test`   │ PR + push    │ `cargo test` — prevents regressions                     │          
  │ `clippy` │ PR + push    │ `cargo clippy -- -D warnings` — enforces lint standards │          
  │ `build`  │ after `test` │ WASM build + artifact upload                            │          
  └──────────┴──────────────┴─────────────────────────────────────────────────────────┘          
                                                                                                 