### PR TITLE
ci: add clippy job and CI badge (#121)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,31 @@ jobs:
       - name: Run tests
         run: cargo test
 
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: clippy
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
   build:
     name: Build WASM
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # smile4money — Competitive Chess Betting on Stellar
 
+[![CI](https://github.com/ayomidearegbeshola29-dev/smile4money/actions/workflows/ci.yml/badge.svg)](https://github.com/ayomidearegbeshola29-dev/smile4money/actions/workflows/ci.yml)
+
 A trustless chess wagering platform built on Stellar Soroban smart contracts. Players stake XLM or USDC before a match, and the winner is automatically paid out the moment the game ends — no middleman, no delays, no trust required.
 
 ## 🎯 What is smile4money?


### PR DESCRIPTION
close #121 


  Add `cargo clippy` to CI pipeline (#121)  

                                                     
                                                                                                 
  Completes the CI setup by adding a clippy job to the GitHub Actions workflow.                  
                                                                                                 
  Changes:                                                                                       
                                                                                                 
  - Added clippy job to .github/workflows/ci.yml that runs cargo clippy -- -D warnings on every  
  PR and push to main/master                                                                     
  - Clippy runs in parallel with the test job, with build still gated on test                    
  - CI status badge added to README.md                                                           
                                                                                                 
  Why: Enforces lint standards and catches common mistakes at the PR level before they land in   
  main.                                                                                          
                                                                                                 