### PR TITLE
doc: add architecture overview and oracle design docs (#110)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,161 @@
+# Architecture Overview
+
+smile4money is a trustless chess wagering platform built on Stellar Soroban smart contracts. This document describes the system components, data flow, and design decisions.
+
+## Components
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Players                              │
+│              (Stellar wallet holders)                       │
+└────────────────────┬────────────────────────────────────────┘
+                     │ create_match / deposit / cancel_match
+                     ▼
+┌─────────────────────────────────────────────────────────────┐
+│                  Escrow Contract                            │
+│                                                             │
+│  - Holds stakes in XLM or USDC                             │
+│  - Manages match lifecycle (Pending → Active → Completed)  │
+│  - Executes payouts on verified result                      │
+│  - Admin pause/unpause controls                             │
+└────────────────────┬────────────────────────────────────────┘
+                     │ submit_result(match_id, winner, caller)
+                     ▲
+┌─────────────────────────────────────────────────────────────┐
+│                  Oracle Contract                            │
+│                                                             │
+│  - Stores verified match results on-chain                  │
+│  - Admin-controlled (off-chain oracle service)             │
+│  - Emits events on result submission                        │
+└────────────────────┬────────────────────────────────────────┘
+                     │ polls game result
+                     ▲
+┌─────────────────────────────────────────────────────────────┐
+│              Off-chain Oracle Service                       │
+│                                                             │
+│  - Watches Lichess / Chess.com APIs                        │
+│  - Verifies game completion                                 │
+│  - Calls oracle contract and escrow contract               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Smart Contracts
+
+### Escrow Contract (`contracts/escrow`)
+
+The escrow contract is the core of the platform. It manages the full match lifecycle.
+
+**State machine:**
+
+```
+Pending ──(both deposit)──► Active ──(submit_result)──► Completed
+   │
+   └──(cancel_match)──► Cancelled
+```
+
+**Key functions:**
+
+| Function | Description |
+|---|---|
+| `initialize(oracle, admin)` | One-time setup. Sets trusted oracle and admin addresses. |
+| `create_match(player1, player2, stake_amount, token, game_id, platform)` | Creates a new match in `Pending` state. |
+| `deposit(match_id, player)` | Player deposits their stake. Match becomes `Active` when both have deposited. |
+| `submit_result(match_id, winner, caller)` | Oracle submits result and triggers payout. |
+| `cancel_match(match_id, caller)` | Either player cancels a `Pending` match. Refunds any deposits. |
+| `get_match(match_id)` | Read a match by ID. |
+| `is_funded(match_id)` | Returns true when both players have deposited. |
+| `get_escrow_balance(match_id)` | Returns total escrowed amount (0, 1×, or 2× stake). |
+| `pause()` / `unpause()` | Admin-only emergency controls. |
+
+**Storage:**
+
+All `Match` records are stored in persistent storage with a TTL of ~30 days (`MATCH_TTL_LEDGERS = 518_400` ledgers at 5s/ledger). TTL is extended on every state-changing write.
+
+**Data keys:**
+
+```rust
+enum DataKey {
+    Match(u64),   // persistent — match record
+    MatchCount,   // instance — monotonic counter
+    Oracle,       // instance — trusted oracle address
+    Admin,        // instance — admin address
+    Paused,       // instance — pause flag
+}
+```
+
+### Oracle Contract (`contracts/oracle`)
+
+The oracle contract is a simple result registry. The off-chain oracle service writes verified results here, and the escrow contract reads from it.
+
+**Key functions:**
+
+| Function | Description |
+|---|---|
+| `initialize(admin)` | One-time setup. Sets the admin (oracle service) address. |
+| `submit_result(match_id, game_id, result)` | Admin submits a verified result. Idempotent guard prevents double-submission. |
+| `get_result(match_id)` | Returns the stored `ResultEntry` for a match. |
+| `has_result(match_id)` | Returns true if a result has been submitted. |
+
+**Storage:**
+
+Results are stored in persistent storage with the same 30-day TTL as match records.
+
+## Data Model
+
+### Match
+
+```rust
+struct Match {
+    id: u64,
+    player1: Address,
+    player2: Address,
+    stake_amount: i128,
+    token: Address,          // XLM or USDC token contract
+    game_id: String,         // Lichess/Chess.com game ID (max 64 chars)
+    platform: Platform,      // Lichess | ChessDotCom
+    state: MatchState,       // Pending | Active | Completed | Cancelled
+    player1_deposited: bool,
+    player2_deposited: bool,
+    created_ledger: u32,     // ledger sequence at creation
+}
+```
+
+### ResultEntry (Oracle)
+
+```rust
+struct ResultEntry {
+    game_id: String,
+    result: MatchResult,     // Player1Wins | Player2Wins | Draw
+}
+```
+
+## Payout Logic
+
+- **Player1 wins**: full pot (`2 × stake_amount`) transferred to `player1`
+- **Player2 wins**: full pot transferred to `player2`
+- **Draw**: each player receives their original `stake_amount` back
+
+## Events
+
+All state changes emit on-chain events for off-chain indexers and frontends.
+
+| Contract | Topic | Data |
+|---|---|---|
+| Escrow | `("match", "created")` | `(match_id, player1, player2, stake_amount)` |
+| Escrow | `("match", "activated")` | `match_id` |
+| Escrow | `("match", "completed")` | `(match_id, winner)` |
+| Escrow | `("match", "cancelled")` | `match_id` |
+| Escrow | `("admin", "paused")` | `()` |
+| Escrow | `("admin", "unpaused")` | `()` |
+| Oracle | `("oracle", "result")` | `(match_id, result)` |
+
+## Network Configuration
+
+Supported networks are defined in `environments.toml`:
+
+| Network | RPC |
+|---|---|
+| `testnet` | `https://soroban-testnet.stellar.org` |
+| `mainnet` | Stellar mainnet |
+| `futurenet` | Stellar futurenet |
+| `standalone` | Local development |

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -1,0 +1,132 @@
+# Oracle Design
+
+The oracle is the bridge between chess platform APIs (Lichess, Chess.com) and the Soroban smart contracts. It is the only component that can submit match results to the escrow contract.
+
+## Role
+
+The oracle solves the fundamental problem of bringing off-chain game results on-chain in a trustless way. Without it, players would need to manually report results — creating an obvious incentive to lie.
+
+The oracle:
+1. Monitors chess platform APIs for game completion
+2. Verifies the result is final and unambiguous
+3. Submits the result to the Oracle Contract on-chain
+4. Calls `submit_result` on the Escrow Contract to trigger payout
+
+## Architecture
+
+```
+Lichess API ──────┐
+                  ├──► Off-chain Oracle Service ──► Oracle Contract
+Chess.com API ────┘           │
+                              └──────────────────► Escrow Contract
+                                                   (submit_result)
+```
+
+The off-chain oracle service is a trusted backend process. Its Stellar address is registered in both contracts at initialization time. Only this address can submit results.
+
+## Oracle Contract
+
+The Oracle Contract (`contracts/oracle`) is an on-chain result registry. It provides a verifiable, immutable record of match outcomes.
+
+### Why a separate oracle contract?
+
+Storing results in a dedicated contract provides:
+- An auditable history of all submitted results, independent of the escrow contract
+- The ability to query results without going through the escrow contract
+- A clean separation of concerns — the oracle contract handles result storage, the escrow contract handles funds
+
+### Functions
+
+**`initialize(admin: Address)`**
+
+Sets the admin address (the off-chain oracle service). Can only be called once — a second call panics with `"Contract already initialized"`.
+
+**`submit_result(match_id: u64, game_id: String, result: MatchResult)`**
+
+Submits a verified result for a match. Requires admin auth. Rejects duplicate submissions with `Error::AlreadySubmitted`. Emits a `("oracle", "result")` event.
+
+**`get_result(match_id: u64) -> ResultEntry`**
+
+Returns the stored result. Returns `Error::ResultNotFound` if no result has been submitted.
+
+**`has_result(match_id: u64) -> bool`**
+
+Returns true if a result exists for the given match ID.
+
+### Result types
+
+```rust
+enum MatchResult {
+    Player1Wins,
+    Player2Wins,
+    Draw,
+}
+
+struct ResultEntry {
+    game_id: String,   // the chess platform game ID
+    result: MatchResult,
+}
+```
+
+## Result Submission Flow
+
+1. Off-chain oracle service detects game completion via Lichess/Chess.com API
+2. Oracle service calls `OracleContract::submit_result(match_id, game_id, result)` — stores result on-chain
+3. Oracle service calls `EscrowContract::submit_result(match_id, winner, caller)` — triggers payout
+4. Escrow contract verifies `caller == oracle` address, then executes payout
+
+```
+Oracle Service
+    │
+    ├─1─► OracleContract::submit_result(match_id, game_id, result)
+    │         └── stores ResultEntry, emits ("oracle", "result") event
+    │
+    └─2─► EscrowContract::submit_result(match_id, winner, caller)
+              └── verifies caller == oracle
+              └── executes payout
+              └── emits ("match", "completed") event
+```
+
+## Platform Integration
+
+### Lichess
+
+Lichess provides a free, open API with no rate limiting for game lookups.
+
+- Game endpoint: `https://lichess.org/api/game/{game_id}`
+- Result field: `winner` (`white` | `black` | absent for draw)
+- Status field: must be a terminal status (`mate`, `resign`, `stalemate`, `draw`, `timeout`, `outoftime`, `cheat`, `noStart`, `unknownFinish`, `variantEnd`)
+
+The oracle service maps Lichess colors to match players using the `game_id` stored in the `Match` record.
+
+### Chess.com
+
+Chess.com provides a developer API for game lookups.
+
+- Game endpoint: `https://api.chess.com/pub/game/{game_id}`
+- Requires `CHESSDOTCOM_API_KEY` in environment
+- Result field: `pgn` headers or `accuracies` — parse `[Result "1-0"]`, `[Result "0-1"]`, or `[Result "1/2-1/2"]`
+
+## Security Properties
+
+- **Single trusted oracle**: Only the registered oracle address can submit results. Any other caller receives `Error::Unauthorized`.
+- **No double submission**: The oracle contract rejects duplicate results for the same `match_id` with `Error::AlreadySubmitted`.
+- **Immutable results**: Once submitted, a result cannot be changed or deleted.
+- **TTL-protected storage**: Result entries have a ~30-day TTL extended on write, preventing expiry during active matches.
+
+## Configuration
+
+Set the following environment variables for the oracle service:
+
+```env
+LICHESS_API_TOKEN=<your-lichess-api-token>
+CHESSDOTCOM_API_KEY=<your-chessdotcom-api-key>
+CONTRACT_ORACLE=<oracle-contract-id>
+CONTRACT_ESCROW=<escrow-contract-id>
+```
+
+## Limitations and Future Work
+
+- The current design requires the oracle service to call both contracts separately. A future improvement would have the oracle contract call the escrow contract directly via cross-contract invocation, removing the need for two separate transactions.
+- The oracle is currently a single point of trust. A multi-sig oracle or decentralized oracle network (e.g., using threshold signatures) would further reduce trust assumptions.
+- There is no on-chain timeout mechanism. If the oracle service goes offline, active matches remain stuck. A future version should allow players to claim a refund after a configurable timeout.


### PR DESCRIPTION
## Summary

Closes #110

Adds two missing documentation files referenced in the README:

- **docs/architecture.md** — Full system architecture overview including component diagram, escrow/oracle contract descriptions, match state machine, data model, payout logic, events table, and network configuration.
- **docs/oracle.md** — Oracle design document covering the oracle's role, contract functions, Lichess/Chess.com API integration details, result submission flow, security properties, and known limitations.

## What was tested
- Docs verified against actual contract source in `contracts/escrow/src/lib.rs` and `contracts/oracle/src/lib.rs`
- All function signatures, error types, events, and data structures match the implementation