### PR TITLE
fix: resolve compile errors in escrow lib.rs

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -229,11 +229,6 @@ impl EscrowContract {
             MATCH_TTL_LEDGERS,
         );
 
-        env.events().publish(
-            (Symbol::new(&env, "match"), symbol_short!("deposit")),
-            (match_id, player),
-        );
-
         Ok(())
     }
 
@@ -245,7 +240,6 @@ impl EscrowContract {
         game_id: String,
         winner: Winner,
         caller: Address,
-        game_id: String,
     ) -> Result<(), Error> {
         if env
             .storage()
@@ -366,23 +360,6 @@ impl EscrowContract {
             match_id,
         );
 
-        Ok(())
-    }
-
-    /// Rotate the trusted oracle address — admin only.
-    /// Use this if the oracle service is compromised or needs to be replaced.
-    pub fn update_oracle(env: Env, new_oracle: Address) -> Result<(), Error> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(Error::Unauthorized)?;
-        admin.require_auth();
-        env.storage().instance().set(&DataKey::Oracle, &new_oracle);
-        env.events().publish(
-            (Symbol::new(&env, "admin"), symbol_short!("oracle")),
-            new_oracle,
-        );
         Ok(())
     }
 


### PR DESCRIPTION
Closes #80

---

## Summary

Fixes three compile errors in `contracts/escrow/src/lib.rs`:

- **Duplicate parameter**: Removed the second `game_id: String` parameter from `submit_result` (Rust does not allow duplicate parameter names)
- **Duplicate function**: Removed the second `update_oracle` definition that appeared after `cancel_match`
- **Duplicate event**: Removed the duplicate `deposit` event publish at the end of the `deposit` function

## Testing

CI will run `cargo test` and `cargo clippy` to verify the build passes.