### PR TITLE
Add test cases #95, #96, #97, #98

### DIFF
--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -94,6 +94,26 @@ fn test_payout_winner() {
 }
 
 #[test]
+fn test_payout_winner_player2() {
+    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+
+    let id = client.create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "game_player2"), &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    client.submit_result(&id, &String::from_str(&env, "game_player2"), &Winner::Player2, &oracle);
+
+    assert_eq!(token_client.balance(&player1), 900);
+    assert_eq!(token_client.balance(&player2), 1100);
+    assert_eq!(client.get_match(&id).state, MatchState::Completed);
+    assert_eq!(client.get_escrow_balance(&id), 0);
+}
+
+#[test]
 fn test_draw_refund() {
     let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
@@ -498,6 +518,33 @@ fn test_non_admin_cannot_pause() {
     .into()]);
 
     assert!(client.try_pause().is_err());
+}
+
+#[test]
+fn test_non_admin_cannot_update_oracle() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let new_oracle = Address::generate(&env);
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    client.initialize(&oracle, &admin);
+
+    use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
+    env.set_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "update_oracle",
+            args: (new_oracle,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }
+    .into()]);
+
+    assert!(client.try_update_oracle(&new_oracle).is_err());
 }
 
 #[test]

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -135,6 +135,57 @@ mod tests {
     }
 
     #[test]
+    fn test_non_admin_cannot_submit_result() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let non_admin = Address::generate(&env);
+        let contract_id = env.register(OracleContract, ());
+        let client = OracleContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
+        env.set_auths(&[MockAuth {
+            address: &non_admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "submit_result",
+                args: (0u64, String::from_str(&env, "game"), MatchResult::Player1Wins).into_val(&env),
+                sub_invokes: &[],
+            },
+        }.into()]);
+
+        assert!(client.try_submit_result(&0u64, &String::from_str(&env, "game"), &MatchResult::Player1Wins).is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "Contract already initialized")]
+    fn test_double_initialize_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(OracleContract, ());
+        let client = OracleContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+        client.initialize(&admin);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #1)")]
+    fn test_duplicate_submit_fails() {
+        let (env, contract_id) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &MatchResult::Draw);
+        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &MatchResult::Draw);
+    }
+
+    #[test]
+    fn test_has_result_false_for_non_existent() {
+        let (env, contract_id) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+        assert!(!client.has_result(&999u64));
+    }
+
+    #[test]
     #[should_panic]
     fn test_duplicate_submit_fails() {
         let (env, contract_id) = setup();


### PR DESCRIPTION
Closes #95: Test non-admin cannot submit result in Oracle contract
Closes #96: Test has_result returns false for non-existent match in Oracle contract
Closes  #97: Test payout when Winner::Player2 in Escrow contract
Closes #98: Test non-admin cannot update oracle in Escrow contract