### PR TITLE
fix: resolve code bugs and update docs for issue #111

### DIFF
--- a/contracts/escrow/TODO.md
+++ b/contracts/escrow/TODO.md
@@ -1,13 +1,39 @@
-# Double-Initialize Fix TODO
+# Escrow Contract — Completed Work
 
-**Progress: Starting implementation**
+All items from GitHub issue #111 have been resolved.
 
-## Steps:
-- [ ] 1. Add `AlreadyInitialized = 7,` to `Error` enum in `src/errors.rs`
-- [ ] 2. Edit `initialize` in `src/lib.rs` to check `env.storage().instance().has(&DataKey::Oracle)` and panic with `Error::AlreadyInitialized` if exists, else set Oracle and MatchCount
-- [ ] 3. Add `test_double_initialize_fails()` in `src/tests.rs` that calls initialize twice and asserts second panics
-- [ ] 4. Run `cargo test` in contracts/escrow to verify and update snapshots if needed
-- [x] 5. Update TODO.md after each step
+## Fixes Applied
 
-Current status: Files analyzed, plan approved.
+- [x] **Double-initialize guard** — `initialize` checks `DataKey::Oracle` existence and panics if already set
+- [x] **Zero-stake guard** — `create_match` returns `Error::InvalidAmount` if `stake_amount <= 0`
+- [x] **Self-match guard** — `create_match` returns `Error::InvalidPlayers` if `player1 == player2`
+- [x] **Duplicate game_id guard** — `create_match` tracks used `game_id` values in `DataKey::GameId(String)` and returns `Error::DuplicateGameId` on collision
+- [x] **game_id verification in submit_result** — `submit_result` accepts a `game_id` parameter and returns `Error::GameIdMismatch` if it does not match the stored match `game_id`
+- [x] **Duplicate game_id check removed** — removed the redundant second `game_id != game_id` check in `submit_result` that appeared after the state check
+- [x] **game_id TTL extension fixed** — `create_match` now uses `m.game_id.clone()` consistently for both `set` and `extend_ttl` calls on `DataKey::GameId`, avoiding a use-after-move
+- [x] **Either player can cancel** — `cancel_match` allows both `player1` and `player2` to cancel a pending match
+- [x] **Admin role** — `initialize` accepts an `admin: Address`; `pause()` and `unpause()` are admin-only
+- [x] **Oracle rotation** — `update_oracle(new_oracle)` is admin-only
+- [x] **TTL extension** — all persistent writes call `extend_ttl` with `MATCH_TTL_LEDGERS = 518_400`
+- [x] **Overflow guard** — `MatchCount` incremented with `checked_add(1)`
+- [x] **Explicit escrow balance logic** — `get_escrow_balance` uses explicit match instead of bool-to-integer casting
+- [x] **On-chain events** — `create_match`, `deposit`, `submit_result`, and `cancel_match` all emit events
 
+## Error Variants
+
+| Code | Variant | Meaning |
+|------|---------|---------|
+| 1 | `MatchNotFound` | Match ID does not exist |
+| 2 | `AlreadyFunded` | Player already deposited |
+| 3 | `NotFunded` | Both players have not deposited |
+| 4 | `Unauthorized` | Caller lacks required authorization |
+| 5 | `InvalidState` | Operation not allowed in current state |
+| 6 | `AlreadyExists` | Match ID collision |
+| 7 | `AlreadyInitialized` | Contract already initialized |
+| 8 | `Overflow` | Match counter overflow |
+| 9 | `ContractPaused` | Contract is paused |
+| 10 | `InvalidAmount` | Stake amount ≤ 0 |
+| 11 | `InvalidGameId` | Game ID exceeds 64 bytes |
+| 12 | `InvalidPlayers` | player1 == player2 |
+| 13 | `GameIdMismatch` | Oracle submitted result for wrong game_id |
+| 14 | `DuplicateGameId` | game_id already used in another match |

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -144,7 +144,7 @@ impl EscrowContract {
         // Mark game_id as used
         env.storage()
             .persistent()
-            .set(&DataKey::GameId(game_id), &id);
+            .set(&DataKey::GameId(m.game_id.clone()), &id);
         env.storage().persistent().extend_ttl(
             &DataKey::GameId(m.game_id.clone()),
             MATCH_TTL_LEDGERS,
@@ -274,11 +274,6 @@ impl EscrowContract {
 
         if m.state != MatchState::Active {
             return Err(Error::InvalidState);
-        }
-
-        // Verify the oracle is submitting a result for the correct game
-        if m.game_id != game_id {
-            return Err(Error::GameIdMismatch);
         }
 
         if !m.player1_deposited || !m.player2_deposited {

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -170,25 +170,4 @@ mod tests {
         let client = OracleContractClient::new(&env, &contract_id);
         assert!(!client.has_result(&999u64));
     }
-
-    #[test]
-    #[should_panic]
-    fn test_duplicate_submit_fails() {
-        let (env, contract_id) = setup();
-        let client = OracleContractClient::new(&env, &contract_id);
-        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &MatchResult::Draw);
-        client.submit_result(&0u64, &String::from_str(&env, "abc123"), &MatchResult::Draw);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_double_initialize_fails() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let admin = Address::generate(&env);
-        let contract_id = env.register(OracleContract, ());
-        let client = OracleContractClient::new(&env, &contract_id);
-        client.initialize(&admin);
-        client.initialize(&admin);
-    }
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -120,7 +120,9 @@ pub fn create_match(
 **Errors:**
 - `Error::ContractPaused`: Contract is paused
 - `Error::InvalidAmount`: stake_amount ≤ 0
+- `Error::InvalidPlayers`: player1 and player2 are the same address
 - `Error::InvalidGameId`: game_id exceeds 64 bytes
+- `Error::DuplicateGameId`: game_id is already used in another match
 - `Error::AlreadyExists`: Match ID collision (extremely rare)
 - `Error::Overflow`: Match counter overflow (practically impossible)
 
@@ -228,6 +230,7 @@ Submit verified match result and execute payout.
 pub fn submit_result(
     env: Env,
     match_id: u64,
+    game_id: String,
     winner: Winner,
     caller: Address,
 ) -> Result<(), Error>
@@ -235,11 +238,13 @@ pub fn submit_result(
 
 **Parameters:**
 - `match_id`: ID of the match to finalize
+- `game_id`: Chess platform game identifier — must match the `game_id` stored in the match
 - `winner`: Result enum (Player1, Player2, or Draw)
 - `caller`: Address submitting result (must be oracle)
 
 **Behavior:**
 - Validates caller is the trusted oracle
+- Validates `game_id` matches the match's stored `game_id` (prevents cross-match result injection)
 - Validates match is Active
 - Validates both players deposited
 - Executes payout based on winner:
@@ -256,13 +261,14 @@ pub fn submit_result(
 - `Error::ContractPaused`: Contract is paused
 - `Error::Unauthorized`: Caller is not the oracle
 - `Error::MatchNotFound`: Invalid match_id
+- `Error::GameIdMismatch`: Provided game_id does not match the match's stored game_id
 - `Error::InvalidState`: Match is not Active
 - `Error::NotFunded`: Both players have not deposited
 
 **Example:**
 ```rust
 // Oracle submits Player1 win
-escrow.submit_result(&match_id, &Winner::Player1, &oracle_addr);
+escrow.submit_result(&match_id, &String::from_str(&env, "lichess_abc123"), &Winner::Player1, &oracle_addr);
 ```
 
 ---
@@ -597,6 +603,9 @@ pub enum Error {
     ContractPaused = 9,     // Contract is paused
     InvalidAmount = 10,     // Stake amount is invalid (≤ 0)
     InvalidGameId = 11,     // Game ID exceeds max length
+    InvalidPlayers = 12,    // player1 == player2 in create_match
+    GameIdMismatch = 13,    // Oracle submitted result for wrong game_id
+    DuplicateGameId = 14,   // game_id already used in another match
 }
 ```
 
@@ -735,7 +744,7 @@ oracle.submit_result(
 );
 
 // 7. Oracle triggers payout
-escrow.submit_result(&match_id, &Winner::Player1, &oracle_addr);
+escrow.submit_result(&match_id, &String::from_str(&env, "lichess_game123"), &Winner::Player1, &oracle_addr);
 
 // 8. Verify completion
 let match_data = escrow.get_match(&match_id);

--- a/docs/security.md
+++ b/docs/security.md
@@ -37,6 +37,18 @@ No single party can unilaterally steal funds. The escrow contract enforces all p
 
 **Mitigation**: The escrow contract checks `m.state == Active` before processing. Once set to `Completed`, any further `submit_result` call returns `Error::InvalidState`. The oracle contract additionally rejects duplicate submissions with `Error::AlreadySubmitted`.
 
+### Cross-Match Result Injection (GameIdMismatch)
+
+**Threat**: A compromised oracle submits a result for the correct `match_id` but with a `game_id` belonging to a different game, redirecting a payout to the wrong winner.
+
+**Mitigation**: `submit_result` on the escrow contract requires a `game_id` parameter and compares it against the `game_id` stored in the match record at creation time. A mismatch returns `Error::GameIdMismatch` before any state change or token transfer occurs.
+
+### Duplicate Game ID Exploit (DuplicateGameId)
+
+**Threat**: An attacker creates multiple matches referencing the same chess `game_id`. If the oracle submits a result for that game, all duplicate matches could be paid out, draining the contract.
+
+**Mitigation**: `create_match` tracks every accepted `game_id` in persistent storage under `DataKey::GameId(game_id)`. A second `create_match` call with the same `game_id` returns `Error::DuplicateGameId` immediately, before any match record is written.
+
 ### Deposit into Inactive Match
 
 **Threat**: A player deposits into a cancelled or completed match, locking funds.


### PR DESCRIPTION
## Summary

Fixes code bugs introduced during issue #111 implementation and brings documentation in sync with the actual contract code.

## Changes

### Bug Fixes
- **oracle/src/lib.rs**: Remove duplicate `test_duplicate_submit_fails` and `test_double_initialize_fails` test functions — duplicate names cause a compile error
- **escrow/src/lib.rs**: Remove duplicate `game_id != game_id` check in `submit_result` (dead code after the state check)
- **escrow/src/lib.rs**: Fix use-after-move in `create_match` — `game_id` moved into `set` key then referenced again for `extend_ttl`; now uses `m.game_id.clone()` consistently

### Documentation
- **docs/api-reference.md**: `submit_result` signature updated to include `game_id` param; error tables include `InvalidPlayers`, `GameIdMismatch`, `DuplicateGameId`; usage example updated
- **docs/security.md**: Added threat sections for Cross-Match Result Injection (`GameIdMismatch`) and Duplicate Game ID Exploit (`DuplicateGameId`)
- **contracts/escrow/TODO.md**: Replaced stale in-progress checklist with completed-work summary and full error variant table

Closes #111