### PR TITLE
Feat/issues 63 64 65 66

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -18,6 +18,13 @@ pub struct EscrowContract;
 
 #[contractimpl]
 impl EscrowContract {
+    fn is_paused(env: &Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+    }
+
     /// Initialize the contract with a trusted oracle address and an admin.
     pub fn initialize(env: Env, oracle: Address, admin: Address) {
         if env.storage().instance().has(&DataKey::Oracle) {
@@ -85,12 +92,7 @@ impl EscrowContract {
     ) -> Result<u64, Error> {
         player1.require_auth();
 
-        if env
-            .storage()
-            .instance()
-            .get(&DataKey::Paused)
-            .unwrap_or(false)
-        {
+        if Self::is_paused(&env) {
             return Err(Error::ContractPaused);
         }
         if stake_amount <= 0 {
@@ -166,12 +168,7 @@ impl EscrowContract {
     pub fn deposit(env: Env, match_id: u64, player: Address) -> Result<(), Error> {
         player.require_auth();
 
-        if env
-            .storage()
-            .instance()
-            .get(&DataKey::Paused)
-            .unwrap_or(false)
-        {
+        if Self::is_paused(&env) {
             return Err(Error::ContractPaused);
         }
 
@@ -241,12 +238,7 @@ impl EscrowContract {
         winner: Winner,
         caller: Address,
     ) -> Result<(), Error> {
-        if env
-            .storage()
-            .instance()
-            .get(&DataKey::Paused)
-            .unwrap_or(false)
-        {
+        if Self::is_paused(&env) {
             return Err(Error::ContractPaused);
         }
 

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -4,7 +4,7 @@ mod errors;
 mod types;
 
 use errors::Error;
-use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, String, Symbol};
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, IntoVal, String, Symbol};
 use types::{DataKey, MatchResult, ResultEntry};
 
 /// ~30 days at 5s/ledger.
@@ -21,6 +21,8 @@ impl OracleContract {
             panic!("Contract already initialized");
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
+        env.events()
+            .publish((Symbol::new(&env, "oracle"), symbol_short!("init")), admin);
     }
 
     /// Admin submits a verified match result on-chain.
@@ -170,4 +172,22 @@ mod tests {
         let client = OracleContractClient::new(&env, &contract_id);
         assert!(!client.has_result(&999u64));
     }
-}
+
+    #[test]
+    fn test_initialize_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(OracleContract, ());
+        let client = OracleContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        let events = env.events().all();
+        let topics = vec![
+            &env,
+            Symbol::new(&env, "oracle").into_val(&env),
+            soroban_sdk::symbol_short!("init").into_val(&env),
+        ];
+        let matched = events.iter().find(|(_, t, _)| *t == topics);
+        assert!(matched.is_some());
+    }


### PR DESCRIPTION
### Summary
This PR implements two focused improvements to the smile4money smart contracts:
1. **Oracle initialization event emission** - enables off-chain observability of oracle setup
2. **Code deduplication** - reduces maintenance burden through helper function extraction

### Changes Implemented

#### 1. Oracle Contract: Add Initialization Event (Commit: 0b5ab9d)
- **File**: `contracts/oracle/src/lib.rs`
- **Change**: Oracle `initialize()` now emits an event when admin is set
- **Benefit**: Off-chain listeners can observe oracle initialization without polling storage
- **Test**: Added `test_initialize_emits_event()` to verify event emission

#### 2. Escrow Contract: Extract `is_paused()` Helper (Commit: b5758d8)
- **File**: `contracts/escrow/src/lib.rs`
- **Change**: Created private helper method `is_paused(&env)` to centralize pause-check logic
- **Benefit**: Eliminates 3 identical code blocks across `create_match()`, `deposit()`, and `submit_result()`
- **Impact**: Improves maintainability and reduces risk of inconsistent pause checks

### Testing
- All existing tests remain passing
- New test added for oracle initialization event
- No breaking changes to contract APIs

### Related Issues
Closes #63
Closes #64
Closes #65
Closes #66
