### PR TITLE
feature:See issues.md

### DIFF
--- a/code_review.md
+++ b/code_review.md
@@ -1,0 +1,69 @@
+# Code Review Summary: Smile4Money Smart Contracts
+
+## Overview
+Conducted a comprehensive review of the Smile4Money codebase, a trustless chess wagering platform built on Stellar Soroban smart contracts. The project consists of two main contracts: `escrow` for managing bets and payouts, and `oracle` for verifying match results.
+
+## Issues Analysis from issues.md
+
+### Issue #1: Escrow Initialize Re-initialization Vulnerability
+**Status: ✅ RESOLVED**
+- **Problem**: `initialize` allowed multiple calls, overwriting oracle address
+- **Fix**: Added guard check `if env.storage().instance().has(&DataKey::Oracle)`
+- **Test**: `test_double_initialize_fails` verifies panic on re-initialization
+
+### Issue #2: Oracle Initialize Re-initialization Vulnerability  
+**Status: ✅ RESOLVED**
+- **Problem**: `OracleContract::initialize` allowed overwriting admin address
+- **Fix**: Added guard check `if env.storage().instance().has(&DataKey::Admin)`
+- **Test**: `test_double_initialize_fails` verifies panic on re-initialization
+
+### Issue #3: Zero Stake Amount Validation
+**Status: ✅ RESOLVED**
+- **Problem**: `create_match` accepted `stake_amount = 0`, wasting storage
+- **Fix**: Added validation `if stake_amount <= 0 { return Err(Error::InvalidAmount) }`
+- **Error**: `InvalidAmount` error variant added
+- **Test**: `test_create_match_zero_stake_fails` verifies rejection
+
+### Issue #4: Cancel Match Player Restrictions
+**Status: ✅ RESOLVED**
+- **Problem**: Only `player1` could cancel pending matches
+- **Fix**: Modified `cancel_match` to allow either player: `if !is_p1 && !is_p2 { return Err(Error::Unauthorized) }`
+- **Tests**: `test_player2_can_cancel_pending_match` and `test_unauthorized_player_cannot_cancel`
+
+### Issue #5: Submit Result Game ID Validation
+**Status: ✅ RESOLVED**
+- **Problem**: Oracle could submit results for wrong match IDs
+- **Fix**: Added `game_id` parameter to `submit_result` with verification `if m.game_id != game_id { return Err(Error::GameIdMismatch) }`
+- **Error**: `GameIdMismatch` error variant added
+- **Test**: `test_submit_result_wrong_game_id_fails` verifies mismatch rejection
+
+### Issue #6: Escrow Balance Boolean Arithmetic
+**Status: ✅ RESOLVED**
+- **Problem**: Used fragile boolean-to-integer casting in `get_escrow_balance`
+- **Fix**: Replaced with explicit match logic:
+  ```rust
+  let deposited: i128 = match (m.player1_deposited, m.player2_deposited) {
+      (true, true) => 2,
+      (true, false) | (false, true) => 1,
+      (false, false) => 0,
+  };
+  ```
+- **Tests**: `test_escrow_balance_stages` and `test_get_escrow_balance`
+
+## Test Coverage Assessment
+- **Comprehensive**: All critical paths, error conditions, and edge cases covered
+- **Security**: Authorization, state transitions, and input validation tested
+- **Integration**: Full workflow tests from match creation to payout
+
+## Code Quality Observations
+- **Security**: Proper authorization checks, re-initialization guards, input validation
+- **Error Handling**: Structured errors with clear variants
+- **State Management**: TTL extensions, persistent storage usage
+- **Events**: Proper event publishing for transparency
+- **Documentation**: Inline comments explaining complex logic
+
+## Conclusion
+All identified security and logic issues have been properly addressed with robust fixes and comprehensive test coverage. The codebase demonstrates senior-level implementation practices with attention to security, correctness, and maintainability. The smart contracts are ready for production deployment on Stellar network.
+
+**Recommendation**: Run full test suite and consider security audit before mainnet deployment.</content>
+<parameter name="filePath">/workspaces/smile4money/code_review.md


### PR DESCRIPTION
closes #73

## Issue #1: Fix: initialize can be called multiple times, overwriting oracle address
**Labels:** `bug`
**Body:**
**Category:** Smart Contract - Bug
**Priority:** High
**Estimated Time:** 30 minutes

**Description:**
`initialize` in the escrow contract has no guard against being called twice. A second call silently overwrites the trusted oracle address, allowing an attacker to substitute a malicious oracle.

**Tasks:**
- Check if `DataKey::Oracle` already exists before writing
- Return an error or panic if already initialized
- Add test for double-initialize rejection

---