### PR TITLE
test: submit_result on cancelled match returns InvalidState (#100)

### DIFF
--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -761,3 +761,21 @@ fn test_non_admin_cannot_call_admin_functions() {
     }));
     assert!(result.is_err());
 }
+
+// Issue #100: Test that submit_result on a cancelled match returns InvalidState
+#[test]
+fn test_submit_result_on_cancelled_match_fails() {
+    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "cancelled_result"), &Platform::Lichess,
+    );
+    client.cancel_match(&id, &player1);
+
+    assert_eq!(
+        client.try_submit_result(&id, &String::from_str(&env, "cancelled_result"), &Winner::Player1, &oracle),
+        Err(Ok(Error::InvalidState))
+    );
+}

--- a/issues.md
+++ b/issues.md
@@ -664,3 +664,18 @@ Verify that calling `submit_result` on a match that has been cancelled returns `
 - Create match, cancel it via `cancel_match`
 - Call `submit_result` on the cancelled match
 - Assert `Error::InvalidState`
+
+## Issue #100: Add Test: submit_result on Cancelled match should return InvalidState
+**Labels:** `testing`
+**Body:**
+**Category:** Smart Contract - Testing
+**Priority:** High
+**Estimated Time:** 30 minutes
+
+**Description:**
+Verify that calling `submit_result` on a match that has been cancelled returns `Error::InvalidState`. Once a match is `Cancelled`, no result should be accepted by the oracle.
+
+**Tasks:**
+- Create a match and cancel it via `cancel_match`
+- Call `submit_result` on the cancelled match
+- Assert `Error::InvalidState` is returned


### PR DESCRIPTION
## Summary

Adds `test_submit_result_on_cancelled_match_fails` to verify that calling `submit_result` on a `Cancelled` match returns `Error::InvalidState`.

## Changes

- `contracts/escrow/src/tests.rs`: new test `test_submit_result_on_cancelled_match_fails`
- `issues.md`: added issue #100 definition

## Test scenario

1. Create a match
2. Cancel it via `cancel_match`
3. Assert `try_submit_result` returns `Err(Ok(Error::InvalidState))`

Closes #100