### PR TITLE
docs: add contributing guide (#104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ stellar keys generate deployer --network testnet
 - [Oracle Design](docs/oracle.md)
 - [Threat Model & Security](docs/security.md)
 - [Roadmap](docs/roadmap.md)
+- [Contributing Guide](docs/contributing.md)
 
 ## 🎓 Smart Contract API
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,96 @@
+# Contributing to smile4money
+
+Thank you for your interest in contributing. This guide covers everything you need to get started.
+
+## Prerequisites
+
+- **Rust** 1.70+ with the `wasm32-unknown-unknown` target
+- **Stellar CLI** — [install guide](https://developers.stellar.org/docs/tools/developer-tools/cli/install-cli)
+- **Git**
+
+Install the WASM target if you haven't already:
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+## Local Setup
+
+```bash
+git clone https://github.com/obajecollinsmicheal-cmd/smile4money.git
+cd smile4money
+cp .env.example .env
+```
+
+## Build
+
+```bash
+./scripts/build.sh
+# or directly:
+cargo build --target wasm32-unknown-unknown --release
+```
+
+## Test
+
+```bash
+./scripts/test.sh
+# or directly:
+cargo test
+```
+
+Run clippy before opening a PR:
+
+```bash
+cargo clippy -- -D warnings
+```
+
+## Branch Naming
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Bug fix | `fix/issue-<N>-short-description` | `fix/issue-1-double-initialize` |
+| New test | `test/issue-<N>-short-description` | `test/issue-21-unauthorized-deposit` |
+| Documentation | `docs/issue-<N>-short-description` | `docs/issue-104-contributing-guide` |
+| Feature | `feat/issue-<N>-short-description` | `feat/issue-17-update-oracle` |
+
+Always branch off `master`:
+
+```bash
+git checkout master
+git pull
+git checkout -b fix/issue-<N>-short-description
+```
+
+## Commit Style
+
+Use the conventional commits format:
+
+```
+<type>: <short summary>
+```
+
+Common types: `fix`, `feat`, `test`, `docs`, `refactor`, `chore`.
+
+Examples:
+```
+fix: guard initialize against double-call
+test: add unauthorized deposit test for issue #21
+docs: add contributing guide
+```
+
+## Opening a Pull Request
+
+1. Push your branch and open a PR against `master`.
+2. Link the issue in the PR body using `Closes #<N>`.
+3. Keep the PR title under 70 characters.
+4. Ensure `cargo test` and `cargo clippy -- -D warnings` pass — CI will check both.
+5. Add a brief description of what changed and how it was tested.
+
+## Reporting Issues
+
+Open a GitHub issue with:
+- A clear title matching the category (`Fix:`, `Test:`, `Doc:`, etc.)
+- Steps to reproduce (for bugs)
+- Expected vs actual behaviour
+
+For security vulnerabilities, add the `security` label and contact the maintainers before public disclosure.

--- a/issues.md
+++ b/issues.md
@@ -664,3 +664,33 @@ Verify that calling `submit_result` on a match that has been cancelled returns `
 - Create match, cancel it via `cancel_match`
 - Call `submit_result` on the cancelled match
 - Assert `Error::InvalidState`
+
+## Issue #100: Add Test: submit_result on Cancelled match should return InvalidState
+**Labels:** `testing`
+**Body:**
+**Category:** Smart Contract - Testing
+**Priority:** High
+**Estimated Time:** 30 minutes
+
+**Description:**
+Verify that calling `submit_result` on a match that has been cancelled returns `Error::InvalidState`. Once a match is `Cancelled`, no result should be accepted by the oracle.
+
+**Tasks:**
+- Create a match and cancel it via `cancel_match`
+- Call `submit_result` on the cancelled match
+- Assert `Error::InvalidState` is returned
+
+## Issue #104: Doc: Add contributing guide
+**Labels:** `documentation`
+**Body:**
+**Category:** Documentation
+**Priority:** Medium
+**Estimated Time:** 1 hour
+
+**Description:**
+There is no contributor guide explaining how to set up the development environment, run tests, submit issues, and open pull requests. New contributors have no clear entry point.
+
+**Tasks:**
+- Create `docs/contributing.md`
+- Cover: prerequisites, local setup, building, testing, branch naming, commit style, and PR process
+- Link from README


### PR DESCRIPTION
## Summary

Adds `docs/contributing.md` — a contributor guide covering everything a new contributor needs to get started.

## Changes

- `docs/contributing.md`: new file with prerequisites, local setup, build, test, branch naming, commit style, PR process, and issue reporting
- `README.md`: added Contributing Guide link to the docs section
- `issues.md`: added issue #104 definition

## Contents

- Prerequisites (Rust, Stellar CLI, WASM target)
- Local setup and environment configuration
- Build and test commands
- Branch naming conventions
- Conventional commit style guide
- PR checklist
- Issue reporting guidelines

Closes #104