### PR TITLE
fix: verify token transfer in deposit before updating state

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -20,4 +20,6 @@ pub enum Error {
     GameIdMismatch = 13,
     /// game_id already used in another match
     DuplicateGameId = 14,
+    /// token transfer failed
+    TransferFailed = 15,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -200,7 +200,9 @@ impl EscrowContract {
         }
 
         let client = token::Client::new(&env, &m.token);
-        client.transfer(&player, &env.current_contract_address(), &m.stake_amount);
+        client
+            .try_transfer(&player, &env.current_contract_address(), &m.stake_amount)
+            .map_err(|_| Error::TransferFailed)?;
 
         if is_p1 {
             m.player1_deposited = true;

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1298,3 +1298,26 @@ fn test_submit_result_on_cancelled_match_fails() {
         Err(Ok(Error::InvalidState))
     );
 }
+
+// Issue #37: deposit must return TransferFailed when the token transfer fails
+#[test]
+fn test_deposit_transfer_failed_insufficient_balance() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Stake amount exceeds player1's balance of 1000
+    let id = client.create_match(
+        &player1, &player2, &5000, &token,
+        &String::from_str(&env, "transfer_fail"), &Platform::Lichess,
+    );
+
+    assert_eq!(
+        client.try_deposit(&id, &player1),
+        Err(Ok(Error::TransferFailed))
+    );
+
+    // State must not have been updated
+    let m = client.get_match(&id);
+    assert!(!m.player1_deposited);
+    assert_eq!(m.state, MatchState::Pending);
+}


### PR DESCRIPTION
- Replace transfer() with try_transfer() in deposit()
- Return Error::TransferFailed if transfer fails
- Add Error::TransferFailed = 15 variant
- Add test: deposit with insufficient balance returns TransferFailed

Closes #210 