### PR TITLE
Fix/deposit state validation

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -25,6 +25,9 @@ use soroban_sdk::contracterror;
 /// | 12   | InvalidPlayers     | player1 and player2 must be different addresses      |
 /// | 13   | GameIdMismatch     | Oracle submitted a result for the wrong game_id      |
 /// | 14   | DuplicateGameId    | game_id is already linked to another match           |
+/// | 15   | TransferFailed     | token transfer failed                                |
+/// | 16   | MatchCancelled     | deposit rejected: match has been cancelled           |
+/// | 17   | MatchCompleted     | deposit rejected: match has already completed        |
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
@@ -77,6 +80,12 @@ pub enum Error {
     DuplicateGameId = 14,
     /// token transfer failed
     TransferFailed = 15,
+
+    /// [E016] Deposit rejected because the match has been cancelled.
+    MatchCancelled = 16,
+
+    /// [E017] Deposit rejected because the match has already completed.
+    MatchCompleted = 17,
 }
 
 impl core::fmt::Display for Error {
@@ -110,6 +119,12 @@ impl core::fmt::Display for Error {
                 write!(f, "[E013] GameIdMismatch: oracle game_id does not match the stored game_id"),
             Error::DuplicateGameId =>
                 write!(f, "[E014] DuplicateGameId: game_id is already linked to another match"),
+            Error::TransferFailed =>
+                write!(f, "[E015] TransferFailed: token transfer failed"),
+            Error::MatchCancelled =>
+                write!(f, "[E016] MatchCancelled: deposit rejected — match has been cancelled"),
+            Error::MatchCompleted =>
+                write!(f, "[E017] MatchCompleted: deposit rejected — match has already completed"),
         }
     }
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -189,6 +189,12 @@ impl EscrowContract {
             .get(&DataKey::Match(match_id))
             .ok_or(Error::MatchNotFound)?;
 
+        if m.state == MatchState::Cancelled {
+            return Err(Error::MatchCancelled);
+        }
+        if m.state == MatchState::Completed {
+            return Err(Error::MatchCompleted);
+        }
         if m.state != MatchState::Pending {
             return Err(Error::InvalidState);
         }

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1335,6 +1335,32 @@ fn test_submit_result_on_cancelled_match_no_deposit_fails() {
     );
 }
 
+// Issue #225: MatchCount overflow returns Error::Overflow instead of wrapping
+#[test]
+fn test_match_count_overflow_returns_error() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Seed the counter at u64::MAX so the next increment would overflow
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .instance()
+            .set(&DataKey::MatchCount, &u64::MAX);
+    });
+
+    assert_eq!(
+        client.try_create_match(
+            &player1,
+            &player2,
+            &100,
+            &token,
+            &String::from_str(&env, "overflow_game"),
+            &Platform::Lichess,
+        ),
+        Err(Ok(Error::Overflow))
+    );
+}
+
 // Issue #209 / Closes #36: Player2 win payout sends full pot to player2
 #[test]
 fn test_player2_win_payout_full_pot() {

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -293,7 +293,7 @@ fn test_deposit_into_completed_match_fails() {
 
     assert_eq!(
         client.try_deposit(&id, &player1),
-        Err(Ok(Error::InvalidState))
+        Err(Ok(Error::MatchCompleted))
     );
 }
 
@@ -314,7 +314,7 @@ fn test_deposit_into_cancelled_match_fails() {
 
     assert_eq!(
         client.try_deposit(&id, &player1),
-        Err(Ok(Error::InvalidState))
+        Err(Ok(Error::MatchCancelled))
     );
 }
 


### PR DESCRIPTION
fix: explicit state validation in deposit for terminal match states

Closes #224 

## Problem

deposit only checked state != Pending, returning the generic Error::InvalidState for both Cancelled and Completed 
matches. Callers had no way to distinguish why the deposit was rejected.

## Changes

- Added Error::MatchCancelled (E016) — returned when depositing into a cancelled match
- Added Error::MatchCompleted (E017) — returned when depositing into a completed match
- deposit now checks for these terminal states explicitly before the generic Pending guard
- Updated test_deposit_into_cancelled_match_fails and test_deposit_into_completed_match_fails to assert the new 
specific error variants

## Notes

InvalidState is still returned for any non-Pending state that isn't Cancelled or Completed (e.g. Active), 
preserving the existing behaviour for that case.
