### PR TITLE
docs/refactor/test: resolve issues #220 #221 #222 #223

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,97 @@
-# Contributing
+# Contributing to smile4money
 
-Open a pull request against `master` with a clear description of your change.
+Thank you for your interest in contributing! This document covers environment setup, running tests, and PR guidelines.
+
+## Prerequisites
+
+- **Rust** 1.70+ — [rustup.rs](https://rustup.rs)
+- **wasm32 target**: `rustup target add wasm32-unknown-unknown`
+- **Stellar CLI** — [install guide](https://developers.stellar.org/docs/tools/developer-tools/cli/install-cli)
+- **Git**
+
+## Local Setup
+
+```bash
+git clone https://github.com/obajecollinsmicheal-cmd/smile4money.git
+cd smile4money
+cp .env.example .env
+# Edit .env with your testnet credentials
+```
+
+## Build
+
+```bash
+./scripts/build.sh
+# or
+cargo build --target wasm32-unknown-unknown --release
+```
+
+## Test
+
+```bash
+./scripts/test.sh
+# or
+cargo test
+```
+
+Run lints before opening a PR:
+
+```bash
+cargo clippy -- -D warnings
+```
+
+## Branch Naming
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Bug fix | `fix/issue-<N>-short-description` | `fix/issue-1-double-initialize` |
+| New test | `test/issue-<N>-short-description` | `test/issue-22-cancel-partial-refund` |
+| Documentation | `docs/issue-<N>-short-description` | `docs/issue-220-contributing-guide` |
+| Feature | `feat/issue-<N>-short-description` | `feat/issue-17-update-oracle` |
+| Refactor | `refactor/issue-<N>-short-description` | `refactor/issue-221-workspace-deps` |
+
+Always branch off `master`:
+
+```bash
+git checkout master && git pull
+git checkout -b fix/issue-<N>-short-description
+```
+
+## Commit Message Format
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>: <short summary (≤72 chars)>
+```
+
+Types: `fix`, `feat`, `test`, `docs`, `refactor`, `chore`.
+
+Examples:
+```
+fix: guard initialize against double-call
+test: cancel_match refunds only player1 when only player1 deposited
+docs: add CONTRIBUTING.md with dev setup and PR guidelines
+refactor: move shared deps to workspace-level Cargo.toml
+```
+
+## Pull Request Checklist
+
+Before submitting a PR, confirm:
+
+- [ ] `cargo test` passes
+- [ ] `cargo clippy -- -D warnings` passes
+- [ ] Branch is up to date with `master`
+- [ ] PR title is under 70 characters
+- [ ] PR body contains `Closes #<N>` for each linked issue
+- [ ] New behaviour is covered by tests
+- [ ] No secrets or `.env` files are committed
+
+## Reporting Issues
+
+Open a GitHub issue with:
+- A clear title prefixed with the category (`Fix:`, `Test:`, `Docs:`, `Feat:`)
+- Steps to reproduce (for bugs)
+- Expected vs actual behaviour
+
+For security vulnerabilities, see [SECURITY.md](SECURITY.md).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+
 [workspace.dependencies]
 soroban-sdk = { version = "22.0.0" }
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,134 @@
+# Security Policy
+
+## Responsible Disclosure
+
+If you discover a security vulnerability, **do not open a public GitHub issue**.
+
+1. Open a GitHub issue with the label `security` and a brief, non-revealing title.
+2. Contact the maintainers directly (via the email in the GitHub profile) with full details.
+3. Allow up to 14 days for an initial response and 90 days for a fix before public disclosure.
+
+We will credit researchers who report valid vulnerabilities.
+
+---
+
+## Threat Model
+
+### Trust Assumptions
+
+| Actor | Trusted for | Not trusted for |
+|-------|-------------|-----------------|
+| Stellar network | Correct Soroban contract execution | — |
+| Oracle service | Accurate game result reporting | Custody of player funds |
+| Admin key | Pause/unpause, oracle rotation | Accessing escrowed funds |
+| Players | Their own key management | Each other |
+
+No single party can unilaterally steal funds. All payout rules are enforced on-chain.
+
+### Attack Vectors
+
+#### Re-initialization
+**Threat**: Attacker calls `initialize` a second time to overwrite oracle/admin.  
+**Mitigation**: Both contracts check storage for an existing `Oracle` key and panic on a second call.
+
+#### Oracle Substitution
+**Threat**: Attacker replaces the oracle address to redirect payouts.  
+**Mitigation**: Oracle address can only be rotated by the admin via `update_oracle`.
+
+#### Unauthorized Result Submission
+**Threat**: Non-oracle address calls `submit_result`.  
+**Mitigation**: `submit_result` compares `caller` against the stored oracle address and returns `Error::Unauthorized` before any state change.
+
+#### Double Result Submission
+**Threat**: Oracle submits a result twice to change the winner.  
+**Mitigation**: Match state is checked for `Active` before processing; `Completed` is terminal. Oracle contract additionally rejects duplicates with `Error::AlreadySubmitted`.
+
+#### Cross-Match Result Injection
+**Threat**: Compromised oracle submits a result for the correct `match_id` but a different `game_id`.  
+**Mitigation**: `submit_result` validates `game_id` against the value stored at match creation. Mismatch returns `Error::GameIdMismatch`.
+
+#### Duplicate Game ID
+**Threat**: Multiple matches reference the same chess `game_id`; one oracle result pays out all of them.  
+**Mitigation**: `create_match` stores each `game_id` in persistent storage and returns `Error::DuplicateGameId` on collision.
+
+#### Deposit into Inactive Match
+**Threat**: Player deposits into a cancelled or completed match, locking funds.  
+**Mitigation**: `deposit` requires `state == Pending`; any other state returns `Error::InvalidState`.
+
+#### Zero-Stake Match
+**Threat**: Match created with `stake_amount = 0` wastes ledger storage.  
+**Mitigation**: `create_match` returns `Error::InvalidAmount` if `stake_amount <= 0`.
+
+#### Self-Match
+**Threat**: Single address creates a match against itself.  
+**Mitigation**: `create_match` checks `player1 != player2` and returns `Error::InvalidPlayers`.
+
+#### Integer Overflow in Match Counter
+**Threat**: `MatchCount` wraps silently, reusing match IDs.  
+**Mitigation**: `create_match` uses `checked_add(1).ok_or(Error::Overflow)?`.
+
+#### Storage Expiry
+**Threat**: A persistent `Match` entry expires mid-game.  
+**Mitigation**: Every persistent write calls `extend_ttl` with `MATCH_TTL_LEDGERS` (~30 days).
+
+#### No Emergency Stop
+**Threat**: Critical bug discovered post-deployment with no way to halt damage.  
+**Mitigation**: Admin can call `pause()` to block `create_match`, `deposit`, and `submit_result`. `cancel_match` remains available so players can recover funds.
+
+---
+
+## Access Control Summary
+
+| Function | Caller |
+|----------|--------|
+| `initialize` | Anyone (once only) |
+| `create_match` | `player1` (requires auth) |
+| `deposit` | `player1` or `player2` (requires auth) |
+| `cancel_match` | `player1` or `player2` (requires auth) |
+| `submit_result` | Registered oracle only |
+| `pause` / `unpause` | Admin only |
+| `update_oracle` | Admin only |
+| `get_match` / `is_funded` / `get_escrow_balance` | Anyone (read-only) |
+
+---
+
+## Audit Checklist
+
+### Authentication & Authorization
+- [ ] All state-mutating functions require `require_auth()` from the appropriate caller
+- [ ] Oracle address is validated before any payout is executed
+- [ ] Admin-only functions reject non-admin callers before any storage write
+
+### State Machine Integrity
+- [ ] All state transitions are guarded; invalid transitions return `Error::InvalidState`
+- [ ] `Completed` and `Cancelled` are terminal — no further transitions possible
+- [ ] `deposit` is rejected on non-`Pending` matches
+
+### Fund Safety
+- [ ] Payout amounts are exactly `stake_amount * 2` (winner) or `stake_amount` each (draw)
+- [ ] `cancel_match` refunds only deposited players; non-depositors receive nothing
+- [ ] No code path allows funds to be sent to an address other than `player1`, `player2`, or back to depositor
+- [ ] `get_escrow_balance` returns 0 for `Completed` and `Cancelled` matches
+
+### Input Validation
+- [ ] `stake_amount <= 0` is rejected
+- [ ] `player1 == player2` is rejected
+- [ ] `game_id` length is bounded by `MAX_GAME_ID_LEN`
+- [ ] Duplicate `game_id` across matches is rejected
+
+### Oracle Security
+- [ ] `game_id` is verified against the stored value on every `submit_result` call
+- [ ] Oracle address can only be changed by the admin
+
+### Storage & TTL
+- [ ] All persistent entries call `extend_ttl` on every write
+- [ ] `MatchCount` increment uses `checked_add` to prevent overflow
+
+### Pause Mechanism
+- [ ] `pause()` blocks `create_match`, `deposit`, and `submit_result`
+- [ ] `cancel_match` remains callable while paused
+- [ ] Only admin can pause/unpause
+
+### Known Limitations
+- The oracle is a centralised component; a compromised oracle key can submit incorrect results. Mitigated by `update_oracle` key rotation.
+- No automatic timeout for unresolved matches; players must manually cancel to recover funds.

--- a/contracts/escrow/Cargo.toml
+++ b/contracts/escrow/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "smile4money-escrow"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1401,3 +1401,39 @@ fn test_player2_win_payout_full_pot() {
     assert_eq!(client.get_match(&id).state, MatchState::Completed);
     assert_eq!(client.get_escrow_balance(&id), 0);
 }
+
+// Issue #222: cancel_match refunds only player1 when only player1 has deposited;
+// player2 balance must remain unchanged and escrow must return to 0.
+#[test]
+fn test_cancel_match_refunds_only_player1_when_only_player1_deposited() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "partial_deposit_cancel"),
+        &Platform::Lichess,
+    );
+
+    // Only player1 deposits
+    client.deposit(&id, &player1);
+    assert_eq!(token_client.balance(&player1), 900);
+    assert_eq!(token_client.balance(&player2), 1000); // player2 untouched
+    assert_eq!(client.get_escrow_balance(&id), 100);
+
+    // Cancel — player2 triggers the cancellation
+    client.cancel_match(&id, &player2);
+
+    // player1 must be fully refunded
+    assert_eq!(token_client.balance(&player1), 1000);
+    // player2 balance must be unchanged (never deposited, must not receive anything)
+    assert_eq!(token_client.balance(&player2), 1000);
+    // Escrow must be empty
+    assert_eq!(client.get_escrow_balance(&id), 0);
+    // Match must be in Cancelled state
+    assert_eq!(client.get_match(&id).state, MatchState::Cancelled);
+}

--- a/contracts/oracle/Cargo.toml
+++ b/contracts/oracle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "smile4money-oracle"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
## Summary

Resolves four issues in a single PR.

### Changes

- **#220** — Added `CONTRIBUTING.md` at the repo root with prerequisites, local setup, build/test commands, branch naming conventions, commit message format, and a PR checklist.
- **#221** — Refactored `Cargo.toml` to use `[workspace.package]` for `version` and `edition`. Both contract manifests now use `version.workspace = true` and `edition.workspace = true`, eliminating duplication. `soroban-sdk` was already workspace-level.
- **#222** — Added `test_cancel_match_refunds_only_player1_when_only_player1_deposited` to `contracts/escrow/src/tests.rs`. Verifies that when only player1 has deposited and the match is cancelled, player1 is fully refunded, player2's balance is unchanged, escrow returns to 0, and state is `Cancelled`.
- **#223** — Added `SECURITY.md` at the repo root covering responsible disclosure policy, full threat model with all attack vectors, access control summary, and a structured audit checklist.

### Testing

- Existing `cargo test` suite covers all contract behaviour.
- New test in `contracts/escrow/src/tests.rs` directly covers the partial-deposit cancellation path.

Closes #220
Closes #221
Closes #222
Closes #223