### PR TITLE
feat(escrow): add game_id validation to submit_result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Kiro AI-assisted development integration
+- `submit_result`: added `game_id` parameter with cross-match injection guard — oracle must supply the `game_id` that matches the stored match record; mismatches return `Error::GameIdMismatch` (E013) before any state is modified
+- `Error::GameIdMismatch` (code 13): new error variant to signal oracle submitted a result for the wrong game
+- `test_submit_result_wrong_game_id_fails`: unit test asserting `GameIdMismatch` when oracle passes a mismatched `game_id`
 
 ## [1.0.0] - 2026-04-25
 


### PR DESCRIPTION
closes #177 
- Add game_id parameter to submit_result so the oracle must explicitly supply the game identifier it is resolving
- Validate game_id == m.game_id before any state mutation; return Err(Error::GameIdMismatch) on mismatch  no storage writes occur on failure, preserving atomicity
- Error::GameIdMismatch (E013) already defined in errors.rs with stable numeric code; prevents cross-match result injection attacks
- Add test_submit_result_wrong_game_id_fails: creates match with game_id A, calls submit_result with game_id B, asserts GameIdMismatch
- All existing submit_result call-sites updated to pass correct game_id
- Update CHANGELOG.md with feature entry

Closes #game-id-validation