### PR TITLE
Fix/cancellation authorization

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -304,20 +304,25 @@ impl EscrowContract {
 
         let client = token::Client::new(&env, &m.token);
 
+        let payout_amount: i128 = match winner {
+            Winner::Draw => m.stake_amount,
+            _ => m.stake_amount * 2,
+        };
+
         match winner {
             Winner::Player1 => client.transfer(
                 &env.current_contract_address(),
                 &m.player1,
-                &(m.stake_amount * 2),
+                &payout_amount,
             ),
             Winner::Player2 => client.transfer(
                 &env.current_contract_address(),
                 &m.player2,
-                &(m.stake_amount * 2),
+                &payout_amount,
             ),
             Winner::Draw => {
-                client.transfer(&env.current_contract_address(), &m.player1, &m.stake_amount);
-                client.transfer(&env.current_contract_address(), &m.player2, &m.stake_amount);
+                client.transfer(&env.current_contract_address(), &m.player1, &payout_amount);
+                client.transfer(&env.current_contract_address(), &m.player2, &payout_amount);
             }
         }
 
@@ -335,7 +340,7 @@ impl EscrowContract {
         );
 
         let topics = (Symbol::new(&env, "match"), symbol_short!("completed"));
-        env.events().publish(topics, (match_id, winner));
+        env.events().publish(topics, (match_id, winner, payout_amount));
 
         Ok(())
     }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -346,7 +346,11 @@ impl EscrowContract {
     }
 
     /// Cancel a pending match and refund any deposits.
-    /// Either player can cancel a pending match.
+    ///
+    /// Authorization model:
+    /// - If neither or only one player has deposited: the calling player's auth suffices.
+    /// - If both players have deposited: both players must authorize, because cancelling
+    ///   would withdraw funds that the other player has already committed.
     pub fn cancel_match(env: Env, match_id: u64, caller: Address) -> Result<(), Error> {
         if Self::is_paused(&env) {
             return Err(Error::ContractPaused);
@@ -368,7 +372,14 @@ impl EscrowContract {
             return Err(Error::Unauthorized);
         }
 
-        caller.require_auth();
+        // When both players have deposited, both must consent to cancellation
+        // to prevent one player from unilaterally withdrawing the other's funds.
+        if m.player1_deposited && m.player2_deposited {
+            m.player1.require_auth();
+            m.player2.require_auth();
+        } else {
+            caller.require_auth();
+        }
 
         let client = token::Client::new(&env, &m.token);
         if m.player1_deposited {

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -472,6 +472,36 @@ fn test_submit_result_wrong_game_id_fails() {
 }
 
 #[test]
+fn test_submit_result_emits_event() {
+    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let stake: i128 = 100;
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &stake,
+        &token,
+        &String::from_str(&env, "event_game"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    client.submit_result(&id, &String::from_str(&env, "event_game"), &Winner::Player1, &oracle);
+
+    let events = env.events().all();
+    let last = events.last().unwrap();
+    assert_eq!(last.0, contract_id);
+    assert_eq!(Symbol::try_from_val(&env, &last.1.get(0).unwrap()).unwrap(), Symbol::new(&env, "match"));
+    assert_eq!(Symbol::try_from_val(&env, &last.1.get(1).unwrap()).unwrap(), symbol_short!("completed"));
+    let (ev_id, ev_winner, ev_payout): (u64, Winner, i128) =
+        TryFromVal::try_from_val(&env, &last.2).unwrap();
+    assert_eq!(ev_id, id);
+    assert_eq!(ev_winner, Winner::Player1);
+    assert_eq!(ev_payout, stake * 2);
+}
+
+#[test]
 #[should_panic(expected = "Contract already initialized")]
 fn test_double_initialize_fails() {
     let env = Env::default();

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -221,6 +221,56 @@ fn test_player2_can_cancel_pending_match() {
 }
 
 #[test]
+#[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+fn test_cancel_with_both_deposits_requires_both_auth() {
+    use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
+
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let player1 = Address::generate(&env);
+    let player2 = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_addr = token_id.address();
+    let asset_client = StellarAssetClient::new(&env, &token_addr);
+    asset_client.mint(&player1, &1000);
+    asset_client.mint(&player2, &1000);
+
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Initialize with mock_all_auths for setup
+    env.mock_all_auths();
+    client.initialize(&oracle, &admin, &token_addr);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token_addr,
+        &String::from_str(&env, "both_deposits"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+
+    // Now set auth to only player1 — should panic because player2's auth is also required
+    env.set_auths(&[MockAuth {
+        address: &player1,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "cancel_match",
+            args: (id, player1.clone()).into_val(&env),
+            sub_invokes: &[],
+        },
+    }
+    .into()]);
+
+    client.cancel_match(&id, &player1);
+}
+
+#[test]
 fn test_cancel_active_match_fails() {
     let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);

--- a/contracts/escrow/src/tests_e2e.rs
+++ b/contracts/escrow/src/tests_e2e.rs
@@ -124,9 +124,10 @@ fn test_e2e_lifecycle_player1_wins() {
         .iter()
         .find(|(_, t, _)| *t == completed_topics)
         .expect("completed event not found");
-    let (ev_id, ev_winner): (u64, Winner) = TryFromVal::try_from_val(&env, &data).unwrap();
+    let (ev_id, ev_winner, ev_payout): (u64, Winner, i128) = TryFromVal::try_from_val(&env, &data).unwrap();
     assert_eq!(ev_id, match_id);
     assert_eq!(ev_winner, Winner::Player1);
+    assert_eq!(ev_payout, stake * 2);
 
     // State: Completed
     let m = client.get_match(&match_id);


### PR DESCRIPTION
#180
Description
Implement proper authorization model for match cancellation when both players have deposited.

Requirements and context

High priority security issue
Must define clear authorization model
Consider atomic state transitions
Suggested execution

Fork the repo and create a branch

git checkout -b fix/cancellation-authorization
```bash

Implement changes
- Document intended cancellation authorization model
- If both players deposited require both authorizations
- Update cancel_match to enforce authorization rules

Test and commit
- Add test_cancel_with_both_deposits_requires_auth()

**Example commit message**
```fix: require proper authorization for match cancellation```bash

**Guidelines**
- Assignment required before starting
- Security review required
- PR description must include: Closes #10
- Timeframe: 3 hours