### PR TITLE
docs: sync api-reference and architecture with current contract code

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -8,28 +8,29 @@ Complete reference for all smart contract functions, types, and errors.
 
 #### `initialize`
 
-Initialize the escrow contract with oracle and admin addresses.
+Initialize the escrow contract with oracle, admin, and default token addresses.
 
 **Signature:**
 ```rust
-pub fn initialize(env: Env, oracle: Address, admin: Address)
+pub fn initialize(env: Env, oracle: Address, admin: Address, token: Address) -> Result<(), Error>
 ```
 
 **Parameters:**
-- `oracle`: Address of the trusted oracle contract
-- `admin`: Address of the contract administrator
+- `oracle`: Address of the trusted oracle that may call `submit_result`
+- `admin`: Address of the contract administrator (pause/unpause, oracle rotation)
+- `token`: Address of the default SEP-41 token contract used for staking
 
 **Behavior:**
-- Sets the oracle address for result verification
-- Sets the admin address for emergency controls
-- Initializes match counter to 0
-- Sets paused state to false
+- Validates `token` by calling a read-only method on it; panics if not a valid token contract
+- Sets the oracle, admin, and token addresses in instance storage
+- Initializes match counter to `0`
+- Sets paused state to `false`
 - Panics if already initialized
 
-**Authorization:** None required (only callable once)
+**Authorization:** None required (callable once only)
 
 **Errors:**
-- Panics with "Contract already initialized" if called twice
+- Panics with `"Contract already initialized"` if called a second time
 
 ---
 
@@ -45,9 +46,10 @@ pub fn pause(env: Env) -> Result<(), Error>
 ```
 
 **Behavior:**
-- Sets paused flag to true
-- Blocks create_match, deposit, and submit_result
-- Emits "admin.paused" event
+- Sets paused flag to `true`
+- Blocks `create_match`, `deposit`, and `submit_result`
+- `cancel_match` remains available so players can recover funds
+- Emits `("admin", "paused")` event
 
 **Authorization:** Requires admin signature
 
@@ -66,9 +68,9 @@ pub fn unpause(env: Env) -> Result<(), Error>
 ```
 
 **Behavior:**
-- Sets paused flag to false
+- Sets paused flag to `false`
 - Re-enables all contract functions
-- Emits "admin.unpaused" event
+- Emits `("admin", "unpaused")` event
 
 **Authorization:** Requires admin signature
 
@@ -87,11 +89,11 @@ pub fn update_oracle(env: Env, new_oracle: Address) -> Result<(), Error>
 ```
 
 **Parameters:**
-- `new_oracle`: Address of the replacement oracle
+- `new_oracle`: Replacement oracle address
 
 **Behavior:**
 - Replaces the stored oracle address with `new_oracle`
-- Emits "admin.oracle" event with the new oracle address
+- Emits `("admin", "oracle")` event with the new oracle address
 
 **Authorization:** Requires admin signature
 
@@ -125,34 +127,36 @@ pub fn create_match(
 ```
 
 **Parameters:**
-- `player1`: Address of the match creator (must sign transaction)
+- `player1`: Address of the match creator (must sign the transaction)
 - `player2`: Address of the opponent
-- `stake_amount`: Amount each player must deposit (in token's smallest unit)
-- `token`: Address of the token contract (e.g., XLM, USDC)
-- `game_id`: Unique identifier from chess platform (max 64 bytes)
-- `platform`: Chess platform enum (Lichess or ChessDotCom)
+- `stake_amount`: Amount each player must deposit (in the token's smallest unit)
+- `token`: Address of the SEP-41 token contract used for this match
+- `game_id`: Unique identifier from the chess platform (max 64 bytes)
+- `platform`: Chess platform enum (`Lichess` or `ChessDotCom`)
 
 **Returns:**
 - `u64`: Unique match ID
 
 **Behavior:**
-- Validates stake_amount > 0
-- Validates game_id length ≤ 64 bytes
-- Creates match in Pending state
+- Validates `stake_amount > 0`
+- Validates `player1 != player2`
+- Validates `game_id` length is between 1 and 64 bytes
+- Rejects duplicate `game_id` values
+- Creates match in `Pending` state
 - Increments match counter with overflow check
-- Extends TTL to 30 days
-- Emits "match.created" event with (match_id, player1, player2, stake_amount)
+- Extends TTL to `MATCH_TTL_LEDGERS` (~30 days)
+- Emits `("match", "created")` event
 
-**Authorization:** Requires player1 signature
+**Authorization:** Requires `player1` signature
 
 **Errors:**
 - `Error::ContractPaused`: Contract is paused
-- `Error::InvalidAmount`: stake_amount ≤ 0
-- `Error::InvalidPlayers`: player1 and player2 are the same address
-- `Error::InvalidGameId`: game_id exceeds 64 bytes
-- `Error::DuplicateGameId`: game_id is already used in another match
-- `Error::AlreadyExists`: Match ID collision (extremely rare)
-- `Error::Overflow`: Match counter overflow (practically impossible)
+- `Error::InvalidAmount`: `stake_amount ≤ 0`
+- `Error::InvalidPlayers`: `player1 == player2`
+- `Error::InvalidGameId`: `game_id` is empty or exceeds 64 bytes
+- `Error::DuplicateGameId`: `game_id` is already used in another match
+- `Error::AlreadyExists`: Match ID collision (internal counter error)
+- `Error::Overflow`: Match counter would exceed `u64::MAX`
 
 **Example:**
 ```rust
@@ -179,32 +183,35 @@ pub fn deposit(env: Env, match_id: u64, player: Address) -> Result<(), Error>
 
 **Parameters:**
 - `match_id`: ID of the match to deposit into
-- `player`: Address making the deposit (must be player1 or player2)
+- `player`: Address making the deposit (must be `player1` or `player2`)
 
 **Behavior:**
-- Validates match exists and is in Pending state
-- Validates caller is player1 or player2
-- Transfers stake_amount tokens from player to contract
-- Marks player as deposited
-- If both players deposited, transitions to Active state
-- Extends TTL to 30 days
-- Emits "match.activated" event if both deposited
+- Validates match exists and is in `Pending` state
+- Validates caller is `player1` or `player2`
+- Transfers `stake_amount` tokens from `player` to the contract
+- Marks the player as deposited
+- If both players have deposited, transitions match to `Active` state and emits `("match", "activated")`
+- Extends TTL to `MATCH_TTL_LEDGERS`
+- Emits `("match", "deposit")` event
 
-**Authorization:** Requires player signature
+**Authorization:** Requires `player` signature
 
 **Errors:**
 - `Error::ContractPaused`: Contract is paused
-- `Error::MatchNotFound`: Invalid match_id
-- `Error::InvalidState`: Match is not Pending
-- `Error::Unauthorized`: Caller is not player1 or player2
-- `Error::AlreadyFunded`: Player already deposited
+- `Error::MatchNotFound`: Invalid `match_id`
+- `Error::MatchCancelled`: Match has been cancelled
+- `Error::MatchCompleted`: Match has already completed
+- `Error::InvalidState`: Match is not in `Pending` state
+- `Error::Unauthorized`: Caller is not `player1` or `player2`
+- `Error::AlreadyFunded`: Player has already deposited
+- `Error::TransferFailed`: Token transfer failed
 
 **Example:**
 ```rust
 // Player 1 deposits
 escrow.deposit(&match_id, &player1_addr);
 
-// Player 2 deposits (match becomes Active)
+// Player 2 deposits — match transitions to Active
 escrow.deposit(&match_id, &player2_addr);
 ```
 
@@ -221,28 +228,30 @@ pub fn cancel_match(env: Env, match_id: u64, caller: Address) -> Result<(), Erro
 
 **Parameters:**
 - `match_id`: ID of the match to cancel
-- `caller`: Address requesting cancellation (must be player1 or player2)
+- `caller`: Address requesting cancellation (must be `player1` or `player2`)
 
 **Behavior:**
-- Validates match is in Pending state
-- Validates caller is player1 or player2
-- Refunds player1 if they deposited
-- Refunds player2 if they deposited
-- Transitions to Cancelled state
-- Extends TTL to 30 days
-- Emits "match.cancelled" event
+- Validates match is in `Pending` state (cancellation is not allowed once `Active`)
+- Validates caller is `player1` or `player2`
+- If both players have deposited, requires authorization from **both** players
+- Refunds `player1` if they deposited
+- Refunds `player2` if they deposited
+- Transitions to `Cancelled` state
+- Extends TTL to `MATCH_TTL_LEDGERS`
+- Emits `("match", "cancelled")` event
+- Allowed even when the contract is paused (so players can always recover funds)
 
-**Authorization:** Requires caller signature (player1 or player2)
+**Authorization:** Requires `caller` signature; if both players have deposited, requires both `player1` and `player2` signatures
 
 **Errors:**
-- `Error::MatchNotFound`: Invalid match_id
-- `Error::InvalidState`: Match is not Pending (already Active, Completed, or Cancelled)
-- `Error::Unauthorized`: Caller is not player1 or player2
+- `Error::MatchNotFound`: Invalid `match_id`
+- `Error::InvalidState`: Match is not `Pending` (already `Active`, `Completed`, or `Cancelled`)
+- `Error::Unauthorized`: Caller is not `player1` or `player2`
 
 **Example:**
 ```rust
-// Either player can cancel
-escrow.cancel_match(&match_id, &player1_addr);
+// Either player can cancel a pending match
+escrow.cancel_match(&match_id, &player2_addr);
 ```
 
 ---
@@ -251,7 +260,7 @@ escrow.cancel_match(&match_id, &player1_addr);
 
 #### `submit_result`
 
-Submit verified match result and execute payout.
+Submit a verified match result and execute payout.
 
 **Signature:**
 ```rust
@@ -266,37 +275,42 @@ pub fn submit_result(
 
 **Parameters:**
 - `match_id`: ID of the match to finalize
-- `game_id`: Chess platform game identifier — must match the `game_id` stored in the match
-- `winner`: Result enum (Player1, Player2, or Draw)
-- `caller`: Address submitting result (must be oracle)
+- `game_id`: Chess platform game identifier — must match the `game_id` stored in the match record
+- `winner`: Result enum (`Player1`, `Player2`, or `Draw`)
+- `caller`: Address submitting the result (must be the registered oracle)
 
 **Behavior:**
-- Validates caller is the trusted oracle
+- Validates `caller` is the trusted oracle address
 - Validates `game_id` matches the match's stored `game_id` (prevents cross-match result injection)
-- Validates match is Active
-- Validates both players deposited
-- Executes payout based on winner:
-  - Player1: Transfers 2x stake to player1
-  - Player2: Transfers 2x stake to player2
-  - Draw: Returns 1x stake to each player
-- Transitions to Completed state
-- Extends TTL to 30 days
-- Emits "match.completed" event with (match_id, winner)
+- Validates match is in `Active` state
+- Validates both players have deposited
+- Executes payout based on `winner`:
+  - `Player1`: Transfers `stake_amount × 2` to `player1`
+  - `Player2`: Transfers `stake_amount × 2` to `player2`
+  - `Draw`: Returns `stake_amount` to each player
+- Transitions to `Completed` state
+- Extends TTL to `MATCH_TTL_LEDGERS`
+- Emits `("match", "completed")` event
 
 **Authorization:** Requires oracle signature
 
 **Errors:**
 - `Error::ContractPaused`: Contract is paused
-- `Error::Unauthorized`: Caller is not the oracle
-- `Error::MatchNotFound`: Invalid match_id
-- `Error::GameIdMismatch`: Provided game_id does not match the match's stored game_id
-- `Error::InvalidState`: Match is not Active
+- `Error::Unauthorized`: Caller is not the registered oracle
+- `Error::MatchNotFound`: Invalid `match_id`
+- `Error::GameIdMismatch`: Provided `game_id` does not match the match's stored `game_id`
+- `Error::InvalidState`: Match is not `Active`
 - `Error::NotFunded`: Both players have not deposited
 
 **Example:**
 ```rust
 // Oracle submits Player1 win
-escrow.submit_result(&match_id, &String::from_str(&env, "lichess_abc123"), &Winner::Player1, &oracle_addr);
+escrow.submit_result(
+    &match_id,
+    &String::from_str(&env, "lichess_abc123"),
+    &Winner::Player1,
+    &oracle_addr,
+);
 ```
 
 ---
@@ -319,7 +333,7 @@ pub fn get_match(env: Env, match_id: u64) -> Result<Match, Error>
 - `Match`: Complete match struct
 
 **Errors:**
-- `Error::MatchNotFound`: Invalid match_id
+- `Error::MatchNotFound`: Invalid `match_id`
 
 **Example:**
 ```rust
@@ -342,10 +356,10 @@ pub fn is_funded(env: Env, match_id: u64) -> Result<bool, Error>
 - `match_id`: ID of the match to check
 
 **Returns:**
-- `bool`: true if both players deposited, false otherwise
+- `bool`: `true` if both players have deposited, `false` otherwise
 
 **Errors:**
-- `Error::MatchNotFound`: Invalid match_id
+- `Error::MatchNotFound`: Invalid `match_id`
 
 **Example:**
 ```rust
@@ -369,20 +383,20 @@ pub fn get_escrow_balance(env: Env, match_id: u64) -> Result<i128, Error>
 - `match_id`: ID of the match to check
 
 **Returns:**
-- `i128`: Total escrowed amount (0, 1x, or 2x stake_amount)
+- `i128`: Total escrowed amount (`0`, `stake_amount`, or `2 × stake_amount`)
 
 **Behavior:**
-- Returns 0 if match is Completed or Cancelled
-- Returns stake_amount if one player deposited
-- Returns 2 * stake_amount if both players deposited
+- Returns `0` if match is `Completed` or `Cancelled`
+- Returns `stake_amount` if exactly one player has deposited
+- Returns `2 × stake_amount` if both players have deposited
 
 **Errors:**
-- `Error::MatchNotFound`: Invalid match_id
+- `Error::MatchNotFound`: Invalid `match_id`
 
 **Example:**
 ```rust
 let balance = escrow.get_escrow_balance(&match_id);
-// balance = 0, stake_amount, or 2 * stake_amount
+// 0, stake_amount, or 2 * stake_amount
 ```
 
 ---
@@ -393,24 +407,25 @@ let balance = escrow.get_escrow_balance(&match_id);
 
 #### `initialize`
 
-Initialize the oracle contract with admin address.
+Initialize the oracle contract with the admin address.
 
 **Signature:**
 ```rust
-pub fn initialize(env: Env, admin: Address)
+pub fn initialize(env: Env, admin: Address) -> Result<(), Error>
 ```
 
 **Parameters:**
-- `admin`: Address of the oracle service (only address that can submit results)
+- `admin`: Address of the oracle service (the only address that may call `submit_result`)
 
 **Behavior:**
-- Sets admin address
-- Panics if already initialized
+- Sets the admin address in instance storage
+- Emits `("oracle", "init")` event with the admin address
+- Returns `Error::AlreadyInitialized` if called a second time
 
-**Authorization:** None required (only callable once)
+**Authorization:** None required (callable once only)
 
 **Errors:**
-- Panics with "Contract already initialized" if called twice
+- `Error::AlreadyInitialized`: Contract has already been initialized
 
 ---
 
@@ -418,7 +433,7 @@ pub fn initialize(env: Env, admin: Address)
 
 #### `submit_result`
 
-Submit a verified match result.
+Submit a verified match result on-chain.
 
 **Signature:**
 ```rust
@@ -431,21 +446,23 @@ pub fn submit_result(
 ```
 
 **Parameters:**
-- `match_id`: ID of the match (from escrow contract)
-- `game_id`: Chess platform game identifier
-- `result`: Result enum (Player1Wins, Player2Wins, or Draw)
+- `match_id`: ID of the match (from the escrow contract)
+- `game_id`: Chess platform game identifier (max 64 bytes, must be non-empty)
+- `result`: Result enum (`Player1Wins`, `Player2Wins`, or `Draw`)
 
 **Behavior:**
-- Validates caller is admin
-- Prevents duplicate submissions
-- Stores result with TTL extension
-- Emits "oracle.result" event with (match_id, result)
+- Validates caller is the admin
+- Validates `game_id` is non-empty and at most 64 bytes
+- Prevents duplicate submissions for the same `match_id`
+- Stores `ResultEntry` in persistent storage with TTL extension
+- Emits `("oracle", "result")` event with `(match_id, result, timestamp)`
 
 **Authorization:** Requires admin signature
 
 **Errors:**
-- `Error::Unauthorized`: Caller is not admin
-- `Error::AlreadySubmitted`: Result already exists for this match_id
+- `Error::Unauthorized`: Caller is not the admin
+- `Error::InvalidGameId`: `game_id` is empty or exceeds 64 bytes
+- `Error::AlreadySubmitted`: A result already exists for this `match_id`
 
 **Example:**
 ```rust
@@ -460,7 +477,7 @@ oracle.submit_result(
 
 #### `get_result`
 
-Retrieve stored result for a match.
+Retrieve the stored result for a match.
 
 **Signature:**
 ```rust
@@ -471,15 +488,15 @@ pub fn get_result(env: Env, match_id: u64) -> Result<ResultEntry, Error>
 - `match_id`: ID of the match to query
 
 **Returns:**
-- `ResultEntry`: Struct containing game_id and result
+- `ResultEntry`: Struct containing `game_id` and `result`
 
 **Errors:**
-- `Error::ResultNotFound`: No result submitted for this match_id
+- `Error::ResultNotFound`: No result has been submitted for this `match_id`
 
 **Example:**
 ```rust
-let result = oracle.get_result(&match_id);
-assert_eq!(result.result, MatchResult::Player1Wins);
+let entry = oracle.get_result(&match_id);
+assert_eq!(entry.result, MatchResult::Player1Wins);
 ```
 
 ---
@@ -497,13 +514,41 @@ pub fn has_result(env: Env, match_id: u64) -> bool
 - `match_id`: ID of the match to check
 
 **Returns:**
-- `bool`: true if result exists, false otherwise
+- `bool`: `true` if a result has been submitted, `false` otherwise
 
 **Example:**
 ```rust
 if oracle.has_result(&match_id) {
-    let result = oracle.get_result(&match_id);
+    let entry = oracle.get_result(&match_id);
 }
+```
+
+---
+
+#### `transfer_admin`
+
+Transfer oracle admin rights to a new address.
+
+**Signature:**
+```rust
+pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), Error>
+```
+
+**Parameters:**
+- `new_admin`: Address of the new admin
+
+**Behavior:**
+- Replaces the stored admin address with `new_admin`
+- Emits `("oracle", "adm_xfer")` event with `(old_admin, new_admin)`
+
+**Authorization:** Requires current admin signature
+
+**Errors:**
+- `Error::Unauthorized`: Caller is not the current admin
+
+**Example:**
+```rust
+oracle.transfer_admin(&new_oracle_service_addr);
 ```
 
 ---
@@ -512,7 +557,7 @@ if oracle.has_result(&match_id) {
 
 ### Match
 
-Complete match record.
+Complete match record stored in the escrow contract.
 
 ```rust
 pub struct Match {
@@ -531,17 +576,17 @@ pub struct Match {
 ```
 
 **Fields:**
-- `id`: Unique match identifier
+- `id`: Unique match identifier (auto-assigned)
 - `player1`: Match creator address
 - `player2`: Opponent address
-- `stake_amount`: Amount each player deposits
-- `token`: Token contract address
+- `stake_amount`: Amount each player deposits (in token's smallest unit)
+- `token`: SEP-41 token contract address
 - `game_id`: Chess platform game identifier
-- `platform`: Chess platform (Lichess or ChessDotCom)
-- `state`: Current match state
-- `player1_deposited`: Whether player1 deposited
-- `player2_deposited`: Whether player2 deposited
-- `created_ledger`: Ledger sequence at creation
+- `platform`: Chess platform (`Lichess` or `ChessDotCom`)
+- `state`: Current match lifecycle state
+- `player1_deposited`: Whether `player1` has deposited
+- `player2_deposited`: Whether `player2` has deposited
+- `created_ledger`: Ledger sequence number at match creation
 
 ---
 
@@ -551,10 +596,10 @@ Match lifecycle states.
 
 ```rust
 pub enum MatchState {
-    Pending,   // Created, awaiting deposits
-    Active,    // Both deposited, game in progress
-    Completed, // Result submitted, payout executed
-    Cancelled, // Cancelled before activation
+    Pending,   // Created, awaiting both deposits
+    Active,    // Both players deposited, game in progress
+    Completed, // Result submitted, payout executed (terminal)
+    Cancelled, // Cancelled before activation (terminal)
 }
 ```
 
@@ -575,13 +620,13 @@ pub enum Platform {
 
 ### Winner
 
-Match outcome for escrow contract.
+Match outcome for the escrow contract's `submit_result`.
 
 ```rust
 pub enum Winner {
-    Player1,
-    Player2,
-    Draw,
+    Player1, // Player1 receives stake_amount × 2
+    Player2, // Player2 receives stake_amount × 2
+    Draw,    // Each player receives their original stake_amount
 }
 ```
 
@@ -589,7 +634,7 @@ pub enum Winner {
 
 ### MatchResult
 
-Match outcome for oracle contract.
+Match outcome for the oracle contract's `submit_result`.
 
 ```rust
 pub enum MatchResult {
@@ -603,7 +648,7 @@ pub enum MatchResult {
 
 ### ResultEntry
 
-Oracle result storage.
+Oracle result record stored in the oracle contract.
 
 ```rust
 pub struct ResultEntry {
@@ -620,20 +665,23 @@ pub struct ResultEntry {
 
 ```rust
 pub enum Error {
-    MatchNotFound = 1,      // Match ID does not exist
-    AlreadyFunded = 2,      // Player already deposited
-    NotFunded = 3,          // Both players have not deposited
-    Unauthorized = 4,       // Caller lacks required authorization
-    InvalidState = 5,       // Operation not allowed in current state
-    AlreadyExists = 6,      // Match ID collision
-    AlreadyInitialized = 7, // Contract already initialized
-    Overflow = 8,           // Match counter overflow
-    ContractPaused = 9,     // Contract is paused
-    InvalidAmount = 10,     // Stake amount is invalid (≤ 0)
-    InvalidGameId = 11,     // Game ID exceeds max length
-    InvalidPlayers = 12,    // player1 == player2 in create_match
-    GameIdMismatch = 13,    // Oracle submitted result for wrong game_id
-    DuplicateGameId = 14,   // game_id already used in another match
+    MatchNotFound      = 1,  // No match exists for the given match_id
+    AlreadyFunded      = 2,  // Player has already deposited for this match
+    NotFunded          = 3,  // submit_result called before both players deposited
+    Unauthorized       = 4,  // Caller lacks required authorization
+    InvalidState       = 5,  // Operation not allowed in the current match state
+    AlreadyExists      = 6,  // Match ID collision (internal counter error)
+    AlreadyInitialized = 7,  // Contract already initialized (unused; initialize panics instead)
+    Overflow           = 8,  // Match counter would exceed u64::MAX
+    ContractPaused     = 9,  // Contract is paused; mutating operations are blocked
+    InvalidAmount      = 10, // stake_amount ≤ 0
+    InvalidGameId      = 11, // game_id is empty or exceeds 64 bytes
+    InvalidPlayers     = 12, // player1 == player2 in create_match
+    GameIdMismatch     = 13, // Oracle submitted result for the wrong game_id
+    DuplicateGameId    = 14, // game_id is already linked to another match
+    TransferFailed     = 15, // Token transfer failed
+    MatchCancelled     = 16, // Deposit rejected — match has been cancelled
+    MatchCompleted     = 17, // Deposit rejected — match has already completed
 }
 ```
 
@@ -641,10 +689,11 @@ pub enum Error {
 
 ```rust
 pub enum Error {
-    Unauthorized = 1,       // Caller is not admin
-    AlreadySubmitted = 2,   // Result already exists
-    ResultNotFound = 3,     // No result for match_id
+    Unauthorized       = 1, // Caller is not the admin
+    AlreadySubmitted   = 2, // A result already exists for this match_id
+    ResultNotFound     = 3, // No result submitted for this match_id
     AlreadyInitialized = 4, // Contract already initialized
+    InvalidGameId      = 5, // game_id is empty or exceeds 64 bytes
 }
 ```
 
@@ -654,73 +703,57 @@ pub enum Error {
 
 ### Escrow Contract Events
 
-#### match.created
-Emitted when a new match is created.
+#### `("match", "created")`
+Emitted when a new match is created via `create_match`.
 
-**Topics:** `("match", "created")`
-
-**Data:** `(match_id: u64, player1: Address, player2: Address, stake_amount: i128)`
+**Data:** `(match_id: u64, player1: Address, player2: Address, stake_amount: i128, game_id: String)`
 
 ---
 
-#### match.activated
-Emitted when both players deposit and match becomes Active.
-
-**Topics:** `("match", "activated")`
+#### `("match", "activated")`
+Emitted when both players have deposited and the match transitions to `Active`.
 
 **Data:** `match_id: u64`
 
 ---
 
-#### match.deposit
+#### `("match", "deposit")`
 Emitted on every individual player deposit.
 
-**Topics:** `("match", "deposit")`
-
-**Data:** `(match_id: u64, player: Address)`
+**Data:** `(match_id: u64, player: Address, stake_amount: i128)`
 
 ---
 
-#### match.completed
-Emitted when result is submitted and payout executed.
+#### `("match", "completed")`
+Emitted when the oracle submits a result and the payout is executed.
 
-**Topics:** `("match", "completed")`
-
-**Data:** `(match_id: u64, winner: Winner)`
+**Data:** `(match_id: u64, winner: Winner, payout_amount: i128)`
 
 ---
 
-#### match.cancelled
-Emitted when a match is cancelled.
+#### `("match", "cancelled")`
+Emitted when a match is cancelled via `cancel_match`.
 
-**Topics:** `("match", "cancelled")`
-
-**Data:** `match_id: u64`
+**Data:** `(match_id: u64, caller: Address)`
 
 ---
 
-#### admin.paused
-Emitted when contract is paused.
-
-**Topics:** `("admin", "paused")`
+#### `("admin", "paused")`
+Emitted when the contract is paused.
 
 **Data:** `()`
 
 ---
 
-#### admin.unpaused
-Emitted when contract is unpaused.
-
-**Topics:** `("admin", "unpaused")`
+#### `("admin", "unpaused")`
+Emitted when the contract is unpaused.
 
 **Data:** `()`
 
 ---
 
-#### admin.oracle
+#### `("admin", "oracle")`
 Emitted when the oracle address is rotated via `update_oracle`.
-
-**Topics:** `("admin", "oracle")`
 
 **Data:** `new_oracle: Address`
 
@@ -728,12 +761,24 @@ Emitted when the oracle address is rotated via `update_oracle`.
 
 ### Oracle Contract Events
 
-#### oracle.result
-Emitted when a result is submitted.
+#### `("oracle", "init")`
+Emitted when the oracle contract is initialized.
 
-**Topics:** `("oracle", "result")`
+**Data:** `admin: Address`
 
-**Data:** `(match_id: u64, result: MatchResult)`
+---
+
+#### `("oracle", "result")`
+Emitted when a result is submitted via `submit_result`.
+
+**Data:** `(match_id: u64, result: MatchResult, timestamp: u64)`
+
+---
+
+#### `("oracle", "adm_xfer")`
+Emitted when admin rights are transferred via `transfer_admin`.
+
+**Data:** `(old_admin: Address, new_admin: Address)`
 
 ---
 
@@ -742,14 +787,15 @@ Emitted when a result is submitted.
 ### Escrow Contract
 
 ```rust
-const MATCH_TTL_LEDGERS: u32 = 518_400;  // ~30 days at 5s/ledger
-const MAX_GAME_ID_LEN: u32 = 64;         // Maximum game_id byte length
+const MATCH_TTL_LEDGERS: u32 = 518_400; // ~30 days at 5 s/ledger
+const MAX_GAME_ID_LEN: u32   = 64;      // Maximum game_id byte length
 ```
 
 ### Oracle Contract
 
 ```rust
-const MATCH_TTL_LEDGERS: u32 = 518_400;  // ~30 days at 5s/ledger
+const MATCH_TTL_LEDGERS: u32 = 518_400; // ~30 days at 5 s/ledger
+const MAX_GAME_ID_LEN: u32   = 64;      // Maximum game_id byte length
 ```
 
 ---
@@ -760,14 +806,14 @@ const MATCH_TTL_LEDGERS: u32 = 518_400;  // ~30 days at 5s/ledger
 
 ```rust
 // 1. Initialize contracts
-escrow.initialize(&oracle_addr, &admin_addr);
+escrow.initialize(&oracle_addr, &admin_addr, &xlm_token_addr);
 oracle.initialize(&oracle_service_addr);
 
 // 2. Create match
 let match_id = escrow.create_match(
     &player1,
     &player2,
-    &100_0000000, // 100 XLM
+    &100_0000000, // 100 XLM (7 decimals)
     &xlm_token,
     &String::from_str(&env, "lichess_game123"),
     &Platform::Lichess,
@@ -775,22 +821,27 @@ let match_id = escrow.create_match(
 
 // 3. Players deposit
 escrow.deposit(&match_id, &player1);
-escrow.deposit(&match_id, &player2);
+escrow.deposit(&match_id, &player2); // match transitions to Active
 
-// 4. Check match is funded
+// 4. Verify match is funded
 assert!(escrow.is_funded(&match_id));
 
-// 5. Players play chess game...
+// 5. Players play the chess game...
 
-// 6. Oracle submits result
+// 6. Oracle records result on-chain
 oracle.submit_result(
     &match_id,
     &String::from_str(&env, "lichess_game123"),
     &MatchResult::Player1Wins,
 );
 
-// 7. Oracle triggers payout
-escrow.submit_result(&match_id, &String::from_str(&env, "lichess_game123"), &Winner::Player1, &oracle_addr);
+// 7. Oracle triggers payout on escrow
+escrow.submit_result(
+    &match_id,
+    &String::from_str(&env, "lichess_game123"),
+    &Winner::Player1,
+    &oracle_addr,
+);
 
 // 8. Verify completion
 let match_data = escrow.get_match(&match_id);
@@ -806,10 +857,8 @@ let match_id = escrow.create_match(...);
 // Player1 deposits
 escrow.deposit(&match_id, &player1);
 
-// Player2 decides not to play
+// Player2 decides not to play — cancels and player1 is refunded
 escrow.cancel_match(&match_id, &player2);
-
-// Player1 gets refund automatically
 ```
 
 ### Emergency Pause
@@ -818,11 +867,25 @@ escrow.cancel_match(&match_id, &player2);
 // Admin pauses contract
 escrow.pause();
 
-// All operations blocked
-assert!(escrow.try_create_match(...).is_err());
+// All mutating operations are blocked
+assert!(escrow.try_create_match(...).is_err()); // Error::ContractPaused
+
+// cancel_match still works so players can recover funds
+escrow.cancel_match(&match_id, &player1);
 
 // Admin unpauses
 escrow.unpause();
 
-// Operations resume
+// Operations resume normally
+```
+
+### Oracle Admin Rotation
+
+```rust
+// Transfer oracle admin to a new key
+oracle.transfer_admin(&new_oracle_service_addr);
+
+// Old admin can no longer submit results
+// New admin can submit results immediately
+oracle.submit_result(&match_id, &game_id, &MatchResult::Draw);
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,10 +87,14 @@ All persistent entries are written with a TTL of `518_400` ledgers (~30 days at 
 
 | Contract | Topics | Data |
 |----------|--------|------|
-| Escrow | `("match", "created")` | `(match_id, player1, player2, stake_amount)` |
+| Escrow | `("match", "created")` | `(match_id, player1, player2, stake_amount, game_id)` |
 | Escrow | `("match", "activated")` | `match_id` |
-| Escrow | `("match", "completed")` | `(match_id, winner)` |
-| Escrow | `("match", "cancelled")` | `match_id` |
+| Escrow | `("match", "deposit")` | `(match_id, player, stake_amount)` |
+| Escrow | `("match", "completed")` | `(match_id, winner, payout_amount)` |
+| Escrow | `("match", "cancelled")` | `(match_id, caller)` |
 | Escrow | `("admin", "paused")` | `()` |
 | Escrow | `("admin", "unpaused")` | `()` |
-| Oracle | `("oracle", "result")` | `(match_id, result)` |
+| Escrow | `("admin", "oracle")` | `new_oracle` |
+| Oracle | `("oracle", "init")` | `admin` |
+| Oracle | `("oracle", "result")` | `(match_id, result, timestamp)` |
+| Oracle | `("oracle", "adm_xfer")` | `(old_admin, new_admin)` |


### PR DESCRIPTION
## Summary

Fixes Issue #111 — `docs/api-reference.md` had multiple inaccuracies relative to the actual Soroban contract implementations.

## Changes

### `docs/api-reference.md`

**Escrow contract fixes:**
- Added missing `token: Address` parameter to `initialize` signature
- Corrected `initialize` error behaviour: it panics with `"Contract already initialized"` (not returns `Error::InvalidToken`)
- Added missing error codes: `TransferFailed = 15`, `MatchCancelled = 16`, `MatchCompleted = 17`
- Fixed `deposit` errors section to include `MatchCancelled` and `MatchCompleted`
- Fixed event data for `match.created` (added `game_id`), `match.deposit` (added `stake_amount`), `match.completed` (added `payout_amount`), `match.cancelled` (added `caller`)

**Oracle contract fixes:**
- Corrected `initialize` signature: returns `Result<(), Error::AlreadyInitialized>` instead of panicking
- Added missing oracle error: `InvalidGameId = 5`
- Added missing `transfer_admin` function with full documentation
- Added missing oracle events: `("oracle", "init")`, `("oracle", "adm_xfer")`
- Fixed `oracle.result` event data: added `timestamp` as third element
- Added `MAX_GAME_ID_LEN` constant for oracle

**Examples:**
- Updated `initialize` call to include `token` parameter
- Added oracle admin rotation example

### `docs/architecture.md`
- Synced events table with actual emitted event payloads
- Added missing events: `match.deposit`, `oracle.init`, `oracle.adm_xfer`

Closes #111