### PR TITLE
docs: add security fix documentation for issues #3, #5, and #8

### DIFF
--- a/docs/issue-3-zero-stake-guard.md
+++ b/docs/issue-3-zero-stake-guard.md
@@ -1,0 +1,94 @@
+# Issue #3: Reject Zero or Negative Stake Amounts in `create_match`
+
+**Labels:** `bug`  
+**Priority:** Medium  
+**Estimated Time:** 30 minutes
+
+## Problem
+
+`EscrowContract::create_match` accepted any `stake_amount` value, including zero and negative numbers. A match created with `stake_amount = 0` wastes ledger storage, produces meaningless escrow entries, and allows the oracle to execute a "payout" of zero tokens — a no-op that still transitions the match to `Completed` and permanently occupies a match ID.
+
+## Root Cause
+
+The function performed no validation on `stake_amount` before writing the match record to persistent storage:
+
+```rust
+// Before fix — no amount guard
+pub fn create_match(
+    env: Env,
+    player1: Address,
+    player2: Address,
+    stake_amount: i128,
+    token: Address,
+    game_id: String,
+    platform: Platform,
+) -> Result<u64, Error> {
+    // stake_amount written directly with no check
+    let m = Match {
+        stake_amount,
+        // ...
+    };
+    env.storage().persistent().set(&DataKey::Match(id), &m);
+    Ok(id)
+}
+```
+
+## Fix
+
+Add an explicit guard at the top of `create_match` that rejects non-positive stake amounts:
+
+```rust
+pub fn create_match(/* ... */) -> Result<u64, Error> {
+    player1.require_auth();
+
+    if Self::is_paused(&env) {
+        return Err(Error::ContractPaused);
+    }
+    if stake_amount <= 0 {
+        return Err(Error::InvalidAmount);
+    }
+    // ... rest of validation and match creation
+}
+```
+
+`InvalidAmount` is defined in `errors.rs`:
+
+```rust
+/// [E010] `stake_amount` must be a positive integer greater than zero.
+InvalidAmount = 10,
+```
+
+## Test Cases
+
+```rust
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_create_match_zero_stake_fails() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    client.create_match(
+        &player1,
+        &player2,
+        &0,
+        &token,
+        &String::from_str(&env, "zero_stake"),
+        &Platform::Lichess,
+    );
+}
+```
+
+Negative amounts are also rejected because `i128` allows negative values and `stake_amount <= 0` covers both cases.
+
+## Impact
+
+Without this guard:
+
+- Any caller could create matches with zero stake, consuming match IDs and ledger storage with no economic value.
+- The oracle could complete such matches, emitting misleading `("match", "completed")` events with a payout of zero.
+- Downstream indexers and frontends would need to filter out zero-stake matches, adding unnecessary complexity.
+
+## Files Changed
+
+- `contracts/escrow/src/lib.rs` — added `if stake_amount <= 0` guard in `create_match`
+- `contracts/escrow/src/errors.rs` — added `InvalidAmount = 10` variant
+- `contracts/escrow/src/tests.rs` — added `test_create_match_zero_stake_fails`

--- a/docs/issue-5-game-id-mismatch.md
+++ b/docs/issue-5-game-id-mismatch.md
@@ -1,0 +1,118 @@
+# Issue #5: Validate `game_id` in `submit_result` to Prevent Cross-Match Result Injection
+
+**Labels:** `bug`, `security`  
+**Priority:** High  
+**Estimated Time:** 1 hour
+
+## Problem
+
+`EscrowContract::submit_result` accepted a `match_id` and a `winner` but did not verify that the oracle's result corresponded to the correct chess game. A compromised or mistaken oracle could submit a result for the right `match_id` but with the outcome of a completely different game, redirecting the payout to the wrong player.
+
+## Root Cause
+
+The original `submit_result` signature took only `match_id` and `winner`. There was no cross-check between the oracle's claimed game and the `game_id` stored in the match record at creation time:
+
+```rust
+// Before fix — no game_id verification
+pub fn submit_result(
+    env: Env,
+    match_id: u64,
+    winner: Winner,
+    caller: Address,
+) -> Result<(), Error> {
+    // caller verified against oracle address ✓
+    // match state verified ✓
+    // BUT: no check that the oracle is submitting for the right game
+    let payout_amount = match winner { /* ... */ };
+    client.transfer(/* ... */);
+    Ok(())
+}
+```
+
+### Attack Scenario
+
+1. Player A and Player B create Match #7 for chess game `lichess_abc`.
+2. Player C and Player D create Match #8 for chess game `lichess_xyz`.
+3. Player C wins `lichess_xyz`.
+4. A compromised oracle submits `submit_result(match_id=7, winner=Player1, ...)` — using the result of `lichess_xyz` to pay out Match #7 to the wrong player.
+
+Without `game_id` verification, the escrow contract has no way to detect this substitution.
+
+## Fix
+
+Add `game_id: String` as a required parameter to `submit_result` and compare it against the `game_id` stored in the match record:
+
+```rust
+pub fn submit_result(
+    env: Env,
+    match_id: u64,
+    game_id: String,      // ← new parameter
+    winner: Winner,
+    caller: Address,
+) -> Result<(), Error> {
+    // ... oracle auth check ...
+
+    let m: Match = env.storage().persistent()
+        .get(&DataKey::Match(match_id))
+        .ok_or(Error::MatchNotFound)?;
+
+    // Verify the oracle is submitting a result for the correct game
+    if m.game_id != game_id {
+        return Err(Error::GameIdMismatch);
+    }
+
+    // ... state checks and payout ...
+}
+```
+
+`GameIdMismatch` is defined in `errors.rs`:
+
+```rust
+/// [E013] The oracle submitted a result whose `game_id` does not match the
+/// `game_id` stored in the match. Prevents cross-match result injection.
+GameIdMismatch = 13,
+```
+
+## Test Cases
+
+```rust
+#[test]
+fn test_submit_result_wrong_game_id_fails() {
+    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "real_game"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+
+    assert_eq!(
+        client.try_submit_result(
+            &id,
+            &String::from_str(&env, "wrong_game"), // ← wrong game_id
+            &Winner::Player1,
+            &oracle,
+        ),
+        Err(Ok(Error::GameIdMismatch))
+    );
+}
+```
+
+## Security Properties
+
+After this fix:
+
+- The oracle must supply the exact `game_id` that was recorded at match creation time.
+- A result submitted for the correct `match_id` but the wrong `game_id` is rejected before any state change or token transfer occurs.
+- The check is performed after oracle authentication and before the state transition, so no partial state changes can occur on a mismatched submission.
+- The `game_id` is immutable once a match is created — it cannot be changed by any party.
+
+## Files Changed
+
+- `contracts/escrow/src/lib.rs` — added `game_id: String` parameter and mismatch check in `submit_result`
+- `contracts/escrow/src/errors.rs` — added `GameIdMismatch = 13` variant
+- `contracts/escrow/src/tests.rs` — added `test_submit_result_wrong_game_id_fails`
+- `docs/security.md` — added "Cross-Match Result Injection" threat entry

--- a/docs/issue-8-oracle-escrow-integration.md
+++ b/docs/issue-8-oracle-escrow-integration.md
@@ -1,0 +1,118 @@
+# Issue #8: Oracle Contract Results Are Not Used by the Escrow Contract
+
+**Labels:** `bug`  
+**Priority:** High  
+**Estimated Time:** 2 hours
+
+## Problem
+
+The oracle contract stored verified match results on-chain, but the escrow contract's `submit_result` function accepted the result directly from the caller rather than reading it from the oracle contract. This made the oracle contract's stored results redundant — the escrow never consulted them, so the on-chain record served no purpose in the payout flow.
+
+## Root Cause
+
+The two contracts operated independently with no integration:
+
+```
+Oracle Contract                    Escrow Contract
+───────────────                    ───────────────
+submit_result(match_id, result)    submit_result(match_id, winner, caller)
+  → stores ResultEntry               → verifies caller == oracle address
+  → emits event                      → executes payout directly
+  (never read by escrow)
+```
+
+The escrow contract verified the *caller's identity* (is this the oracle address?) but never verified the *result content* against what the oracle contract had recorded on-chain.
+
+## Chosen Architecture
+
+After evaluating two options — (a) escrow reads from oracle contract, (b) oracle calls escrow directly — the team chose a **dual-submission model**:
+
+1. The off-chain oracle service calls `oracle_contract.submit_result(match_id, game_id, result)` to record the result on-chain.
+2. The off-chain oracle service then calls `escrow_contract.submit_result(match_id, game_id, winner, oracle_address)` to trigger the payout.
+
+The escrow contract verifies:
+- The caller is the registered oracle address (`caller == DataKey::Oracle`)
+- The `game_id` matches the match record (prevents cross-match injection — see Issue #5)
+- The match is in `Active` state
+
+This approach keeps the contracts loosely coupled (the escrow does not need to know the oracle contract's address) while the `game_id` cross-check provides the binding between the two submissions.
+
+## Integration Flow
+
+```
+Off-chain Oracle Service
+        │
+        ├─1─► oracle_contract.submit_result(match_id, game_id, result)
+        │         └─ stores ResultEntry on-chain
+        │         └─ emits ("oracle", "result") event
+        │
+        └─2─► escrow_contract.submit_result(match_id, game_id, winner, oracle_addr)
+                  └─ verifies caller == stored oracle address
+                  └─ verifies game_id matches match record
+                  └─ verifies match state == Active
+                  └─ executes token payout
+                  └─ emits ("match", "completed") event
+```
+
+The oracle contract's on-chain record serves as an **immutable audit trail** — any observer can verify that the result submitted to the escrow matches what the oracle recorded, without trusting the off-chain service's logs.
+
+## Integration Test
+
+```rust
+// Full oracle → escrow flow
+#[test]
+fn test_oracle_to_escrow_full_flow() {
+    // Setup both contracts
+    let escrow_client = /* ... */;
+    let oracle_client = /* ... */;
+
+    // Create and fund match
+    let match_id = escrow_client.create_match(
+        &player1, &player2, &100, &token,
+        &String::from_str(&env, "lichess_abc123"),
+        &Platform::Lichess,
+    );
+    escrow_client.deposit(&match_id, &player1);
+    escrow_client.deposit(&match_id, &player2);
+
+    // Oracle records result on-chain
+    oracle_client.submit_result(
+        &match_id,
+        &String::from_str(&env, "lichess_abc123"),
+        &MatchResult::Player1Wins,
+    );
+
+    // Verify oracle stored the result
+    assert!(oracle_client.has_result(&match_id));
+    assert_eq!(
+        oracle_client.get_result(&match_id).result,
+        MatchResult::Player1Wins
+    );
+
+    // Oracle triggers payout on escrow
+    escrow_client.submit_result(
+        &match_id,
+        &String::from_str(&env, "lichess_abc123"),
+        &Winner::Player1,
+        &oracle_addr,
+    );
+
+    // Verify payout executed
+    assert_eq!(token_client.balance(&player1), 1100);
+    assert_eq!(token_client.balance(&player2), 900);
+    assert_eq!(escrow_client.get_match(&match_id).state, MatchState::Completed);
+}
+```
+
+## Security Properties
+
+- **Immutable audit trail**: The oracle contract's stored `ResultEntry` cannot be overwritten (`AlreadySubmitted` guard). Any discrepancy between the oracle record and the escrow payout is detectable on-chain.
+- **game_id binding**: Both submissions must use the same `game_id`. The escrow verifies this against the match record, preventing a scenario where the oracle records one result but submits a different winner to the escrow.
+- **Loose coupling**: The escrow contract does not hold a reference to the oracle contract address. The oracle contract address is only used for caller authentication. This means the oracle contract can be upgraded or replaced without redeploying the escrow.
+
+## Files Changed
+
+- `contracts/escrow/src/lib.rs` — `submit_result` now requires `game_id` parameter and verifies it against the match record
+- `contracts/oracle/src/lib.rs` — `submit_result` stores `ResultEntry` with `game_id` and emits event with timestamp
+- `docs/oracle.md` — updated result submission flow diagram
+- `docs/architecture.md` — updated integration diagram


### PR DESCRIPTION
## Summary

Adds dedicated documentation files for three security-critical bug fixes that were implemented in the contracts but lacked documentation, following the pattern of `issue-1-initialize-guard.md` and `issue-2-oracle-initialize-guard.md`.

## New Files

### `docs/issue-3-zero-stake-guard.md`
Documents the zero/negative `stake_amount` guard added to `create_match`. Explains why zero-stake matches waste ledger storage and produce misleading completed events, covers the `InvalidAmount = 10` error, and includes the test case.

### `docs/issue-5-game-id-mismatch.md`
Documents the `game_id` cross-check added to `submit_result` to prevent cross-match result injection. Includes a concrete attack scenario, the `GameIdMismatch = 13` error definition, the fix, and the security properties of the check.

### `docs/issue-8-oracle-escrow-integration.md`
Documents the dual-submission architecture chosen for oracle-escrow integration. Explains why the oracle contract results were previously unused by the escrow, describes the full integration flow, audit trail properties, and loose-coupling design rationale.

Closes #366 
Closes #367 
Closes #368 
Closes #369 