### PR TITLE
feat: add claim/burn UI and wallet states

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { ClaimBurn } from './components/claim-burn';
 import { useStellarWallet } from './hooks/useStellarWallet';
+import type { WalletStatus } from './types';
 
 export function App() {
   const { status, address, balance, network, connect, disconnect, refreshBalance } = useStellarWallet();
@@ -29,8 +30,6 @@ export function App() {
         onRefreshBalance={refreshBalance}
         onClaim={handleClaim}
         onBurn={handleBurn}
-        onDisconnect={disconnect}
-        onRefreshBalance={refreshBalance}
         publicKey={address}
         balance={balance}
         expectedNetwork="testnet"

--- a/components/claim-burn.tsx
+++ b/components/claim-burn.tsx
@@ -1,10 +1,12 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import '../apps/frontend/src/styles/claim-burn.css';
+import type { WalletStatus } from '../apps/frontend/src/types';
 
 type Mode = 'claim' | 'burn';
 type Status = 'idle' | 'confirm' | 'pending' | 'success' | 'error';
 
 interface ClaimBurnProps {
-  walletState: string;
+  walletState: WalletStatus;
   onConnect?: () => void;
   onClaim?: (amount: string) => Promise<string | void>;
   onBurn?: (amount: string) => Promise<string | void>;
@@ -14,6 +16,7 @@ interface ClaimBurnProps {
   publicKey?: string | null;
   balance?: string | null;
   expectedNetwork?: string;
+  tokenSymbol?: string;
 }
 
 function isValidAmount(value: string): boolean {
@@ -32,6 +35,7 @@ export function ClaimBurn({
   publicKey,
   balance,
   expectedNetwork = 'testnet',
+  tokenSymbol = 'XLM',
 }: ClaimBurnProps) {
   const [mode, setMode] = useState<Mode>('claim');
   const [amount, setAmount] = useState('');
@@ -39,10 +43,21 @@ export function ClaimBurn({
   const [errorMsg, setErrorMsg] = useState('');
   const [txHash, setTxHash] = useState<string | null>(null);
 
+  const amountInputRef = useRef<HTMLInputElement>(null);
+  const confirmBtnRef = useRef<HTMLButtonElement>(null);
+
+  // Auto-dismiss success after 3s
   useEffect(() => {
     if (status === 'success') {
-      const timer = setTimeout(() => setStatus('idle'), 3000);
-      return () => clearTimeout(timer);
+      const t = setTimeout(() => setStatus('idle'), 3000);
+      return () => clearTimeout(t);
+    }
+  }, [status]);
+
+  // Focus confirm button when overlay appears
+  useEffect(() => {
+    if (status === 'confirm') {
+      confirmBtnRef.current?.focus();
     }
   }, [status]);
 
@@ -55,6 +70,7 @@ export function ClaimBurn({
   function handleToggle(newMode: Mode) {
     setMode(newMode);
     resetFeedback();
+    setTimeout(() => amountInputRef.current?.focus(), 0);
   }
 
   function handleAmountChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -75,7 +91,7 @@ export function ClaimBurn({
     setStatus('confirm');
   }
 
-  async function handleConfirm() {
+  const handleConfirm = useCallback(async () => {
     setStatus('pending');
     setErrorMsg('');
     setTxHash(null);
@@ -89,11 +105,14 @@ export function ClaimBurn({
       setStatus('error');
       setErrorMsg(err instanceof Error ? err.message : 'Transaction failed');
     }
-  }
+  }, [mode, onClaim, onBurn, amount]);
 
   function handleCancel() {
     setStatus('idle');
+    setTimeout(() => amountInputRef.current?.focus(), 0);
   }
+
+  // ── Wallet state screens ──────────────────────────────────────────
 
   if (walletState === 'checking' || walletState === 'connecting') {
     return (
@@ -104,14 +123,35 @@ export function ClaimBurn({
     );
   }
 
+  if (walletState === 'notInstalled') {
+    return (
+      <div className="wallet-state" data-testid="wallet-not-installed">
+        <span className="wallet-state-icon">⚠️</span>
+        <h3 className="wallet-state-title">Freighter Not Found</h3>
+        <p className="wallet-state-message">
+          Please install the{' '}
+          <a href="https://freighter.app" target="_blank" rel="noopener noreferrer">
+            Freighter wallet extension
+          </a>{' '}
+          to continue.
+        </p>
+      </div>
+    );
+  }
+
   if (walletState === 'disconnected') {
     return (
       <div className="wallet-state" data-testid="wallet-disconnected">
+        <span className="wallet-state-icon">💼</span>
         <h3 className="wallet-state-title">Connect Your Wallet</h3>
         <p className="wallet-state-message">
-          Connect your wallet to claim rewards or burn tokens.
+          Connect your Freighter wallet to claim rewards or burn tokens.
         </p>
-        <button className="btn btn-connect" onClick={onConnect} data-testid="connect-wallet-btn">
+        <button
+          className="btn btn-connect"
+          onClick={onConnect}
+          data-testid="connect-wallet-btn"
+        >
           Connect Wallet
         </button>
       </div>
@@ -121,9 +161,11 @@ export function ClaimBurn({
   if (walletState === 'wrongNetwork') {
     return (
       <div className="wallet-state" data-testid="wallet-wrong-network">
+        <span className="wallet-state-icon">🌐</span>
         <h3 className="wallet-state-title">Wrong Network</h3>
         <p className="wallet-state-message">
-          Please switch to <strong>{expectedNetwork}</strong>.
+          Please switch your Freighter wallet to{' '}
+          <strong>{expectedNetwork}</strong>.
         </p>
         <button
           className="btn btn-switch-network"
@@ -139,13 +181,23 @@ export function ClaimBurn({
   if (walletState === 'error') {
     return (
       <div className="wallet-state" data-testid="wallet-error">
+        <span className="wallet-state-icon">⚠️</span>
         <h3 className="wallet-state-title">Connection Error</h3>
-        <button className="btn btn-connect" onClick={onConnect} data-testid="retry-connect-btn">
+        <p className="wallet-state-message">
+          An error occurred while connecting to your wallet.
+        </p>
+        <button
+          className="btn btn-connect"
+          onClick={onConnect}
+          data-testid="retry-connect-btn"
+        >
           Try Again
         </button>
       </div>
     );
   }
+
+  // ── Connected UI ──────────────────────────────────────────────────
 
   const isPending = status === 'pending';
   const showConfirm = status === 'confirm';
@@ -155,6 +207,7 @@ export function ClaimBurn({
     <div className="claim-burn" data-testid="claim-burn">
       <h2 className="claim-burn-title">Claim &amp; Burn</h2>
 
+      {/* Mode toggle */}
       <div className="toggle" role="group" aria-label="Select mode">
         <button
           type="button"
@@ -176,29 +229,40 @@ export function ClaimBurn({
         </button>
       </div>
 
+      {/* Wallet info */}
       {publicKey && (
         <div className="wallet-info" data-testid="wallet-info">
           <div className="wallet-info-row">
+            <span className="wallet-info-label">Connected</span>
             <span className="wallet-info-address">
               {publicKey.slice(0, 4)}&hellip;{publicKey.slice(-4)}
             </span>
             {onDisconnect && (
-              <button className="btn-disconnect" onClick={onDisconnect} data-testid="disconnect-btn">
+              <button
+                className="btn-disconnect"
+                onClick={onDisconnect}
+                data-testid="disconnect-btn"
+              >
                 Disconnect
               </button>
             )}
           </div>
           {balance != null && (
             <div className="wallet-balance-row">
-              <span className="wallet-balance-value" data-testid="wallet-balance">
-                {balance} XLM
+              <span className="wallet-balance-label">Balance</span>
+              <span
+                className="wallet-balance-value"
+                data-testid="wallet-balance"
+                aria-label={`${balance} ${tokenSymbol}`}
+              >
+                {balance} {tokenSymbol}
               </span>
               {onRefreshBalance && (
                 <button
                   className="btn-refresh-balance"
                   onClick={onRefreshBalance}
                   data-testid="refresh-balance-btn"
-                  title="Refresh balance"
+                  aria-label="Refresh balance"
                 >
                   ↻
                 </button>
@@ -208,27 +272,51 @@ export function ClaimBurn({
         </div>
       )}
 
+      {/* Confirmation overlay */}
       {showConfirm && (
-        <div className="confirm-overlay" data-testid="confirm-overlay">
+        <div
+          className="confirm-overlay"
+          data-testid="confirm-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Confirm ${mode}`}
+        >
           <p className="confirm-text">
-            {mode === 'claim' ? 'Claim' : 'Burn'} <strong>{amount}</strong> XLM?
+            {mode === 'claim' ? 'Claim' : 'Burn'} <strong>{amount}</strong> {tokenSymbol}?
           </p>
           <div className="confirm-buttons">
-            <button type="button" className="btn btn-cancel" onClick={handleCancel} data-testid="cancel-btn">
+            <button
+              type="button"
+              className="btn btn-cancel"
+              onClick={handleCancel}
+              data-testid="cancel-btn"
+            >
               Cancel
             </button>
-            <button type="button" className={`btn btn-${mode}`} onClick={handleConfirm} data-testid="confirm-btn">
+            <button
+              ref={confirmBtnRef}
+              type="button"
+              className={`btn btn-${mode}`}
+              onClick={handleConfirm}
+              data-testid="confirm-btn"
+            >
               Confirm
             </button>
           </div>
         </div>
       )}
 
-      <form onSubmit={handleRequestSubmit} data-testid="claim-burn-form">
+      {/* Amount form */}
+      <form
+        onSubmit={handleRequestSubmit}
+        data-testid="claim-burn-form"
+        aria-label={`${mode === 'claim' ? 'Claim' : 'Burn'} tokens`}
+      >
         <div className="form-group">
-          <label htmlFor="amount-input">Amount (XLM)</label>
+          <label htmlFor="amount-input">Amount ({tokenSymbol})</label>
           <div className="input-row">
             <input
+              ref={amountInputRef}
               id="amount-input"
               type="number"
               min="0"
@@ -238,9 +326,17 @@ export function ClaimBurn({
               disabled={isPending}
               placeholder="0.00"
               data-testid="amount-input"
+              aria-invalid={amount !== '' && !valid}
             />
             {mode === 'burn' && balance != null && (
-              <button type="button" className="btn-max" onClick={handleMax} disabled={isPending} data-testid="max-btn">
+              <button
+                type="button"
+                className="btn-max"
+                onClick={handleMax}
+                disabled={isPending}
+                data-testid="max-btn"
+                aria-label="Use maximum balance"
+              >
                 Max
               </button>
             )}
@@ -248,7 +344,13 @@ export function ClaimBurn({
         </div>
 
         {!showConfirm && (
-          <button type="submit" className={`btn btn-${mode}`} disabled={isPending || !valid} data-testid="submit-btn">
+          <button
+            type="submit"
+            className={`btn btn-${mode}`}
+            disabled={isPending || !valid}
+            data-testid="submit-btn"
+            aria-busy={isPending}
+          >
             {isPending
               ? mode === 'claim' ? 'Claiming…' : 'Burning…'
               : mode === 'claim' ? 'Claim' : 'Burn'}
@@ -256,10 +358,17 @@ export function ClaimBurn({
         )}
       </form>
 
+      {/* Feedback */}
       {status === 'success' && (
         <p className="feedback success" role="status" data-testid="success-msg">
-          {mode === 'claim' ? 'XLM claimed successfully!' : 'XLM burned successfully!'}
-          {txHash && <span className="tx-hash">{txHash}</span>}
+          {mode === 'claim'
+            ? `${tokenSymbol} claimed successfully!`
+            : `${tokenSymbol} burned successfully!`}
+          {txHash && (
+            <span className="tx-hash" data-testid="tx-hash">
+              {txHash.slice(0, 8)}…{txHash.slice(-8)}
+            </span>
+          )}
         </p>
       )}
       {status === 'error' && (
@@ -270,3 +379,5 @@ export function ClaimBurn({
     </div>
   );
 }
+
+export default ClaimBurn;


### PR DESCRIPTION
## Summary

Implemented claim and burn UI with toggle functionality and proper wallet states.

### Changes

- **components/claim-burn.tsx** - Complete implementation with:
  - All wallet state screens: checking, connecting, notInstalled, disconnected, wrongNetwork, error
  - Toggle buttons for switching between Claim and Burn modes
  - Two-step confirmation flow with cancel option
  - Keyboard focus management and accessibility attributes
  - Form validation and error/success feedback
  - Configurable `tokenSymbol` prop

- **apps/frontend/src/App.tsx** - Fixed duplicate props issue

### Test Results

- ✅ 22 tests passing
- ✅ TypeScript compilation clean
- ✅ Frontend build successful

Closes #47