### PR TITLE
fix: resolve Clippy, Format, and Test CI failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 edition = "2021"
 
 [workspace.dependencies]
-soroban-sdk = { version = "22.0.0" }
+soroban-sdk = { version = "22.0.11" }
 
 [profile.release]
 opt-level = "z"

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -155,7 +155,7 @@ impl EscrowContract {
             player2,
             stake_amount,
             token,
-            game_id: game_id.clone(),
+            game_id,
             platform,
             state: MatchState::Pending,
             player1_deposited: false,
@@ -184,7 +184,7 @@ impl EscrowContract {
 
         env.events().publish(
             (Symbol::new(&env, "match"), symbol_short!("created")),
-            (id, m.player1.clone(), m.player2.clone(), stake_amount, m.game_id.clone()),
+            (id, m.player1, m.player2, stake_amount, m.game_id),
         );
 
         Ok(id)
@@ -420,7 +420,7 @@ impl EscrowContract {
 
         env.events().publish(
             (Symbol::new(&env, "match"), symbol_short!("cancelled")),
-            (match_id, caller.clone()),
+            (match_id, caller),
         );
 
         Ok(())

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -35,7 +35,7 @@ impl EscrowContract {
     ///
     /// # Errors
     ///
-    /// Returns `Error::InvalidToken` if `token` is not a valid SEP-41 token contract.
+    /// Panics if `token` is not a valid SEP-41 token contract.
     pub fn initialize(
         env: Env,
         oracle: Address,

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -275,7 +275,8 @@ impl EscrowContract {
     }
 
     /// Oracle submits the verified match result and triggers payout.
-    /// `game_id` must match the game_id stored in the match to prevent cross-match result injection.
+    /// `game_id` must match the game_id stored in the match to prevent
+    /// cross-match result injection.
     pub fn submit_result(
         env: Env,
         match_id: u64,

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -274,7 +274,7 @@ fn test_cancel_with_both_deposits_requires_both_auth() {
     client.deposit(&id, &player2);
 
     // Now set auth to only player1 — should panic because player2's auth is also required
-    env.set_auths(&[MockAuth {
+    env.mock_auths(&[MockAuth {
         address: &player1,
         invoke: &MockAuthInvoke {
             contract: &contract_id,
@@ -282,8 +282,7 @@ fn test_cancel_with_both_deposits_requires_both_auth() {
             args: (id, player1.clone()).into_val(&env),
             sub_invokes: &[],
         },
-    }
-    .into()]);
+    }]);
 
     client.cancel_match(&id, &player1);
 }
@@ -436,7 +435,7 @@ fn test_submit_result_random_caller_is_unauthorized() {
     let game_id = String::from_str(&env, "random_caller");
 
     // Provide auth for the random address — the contract must still reject it.
-    env.set_auths(&[MockAuth {
+    env.mock_auths(&[MockAuth {
         address: &random,
         invoke: &MockAuthInvoke {
             contract: &contract_id,
@@ -444,8 +443,7 @@ fn test_submit_result_random_caller_is_unauthorized() {
             args: (id, game_id.clone(), Winner::Player1, random.clone()).into_val(&env),
             sub_invokes: &[],
         },
-    }
-    .into()]);
+    }]);
 
     assert_eq!(
         client.try_submit_result(&id, &game_id, &Winner::Player1, &random),
@@ -889,7 +887,7 @@ fn test_non_admin_cannot_pause() {
     let non_admin = Address::generate(&env);
 
     use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
-    env.set_auths(&[MockAuth {
+    env.mock_auths(&[MockAuth {
         address: &non_admin,
         invoke: &MockAuthInvoke {
             contract: &contract_id,
@@ -897,8 +895,7 @@ fn test_non_admin_cannot_pause() {
             args: ().into_val(&env),
             sub_invokes: &[],
         },
-    }
-    .into()]);
+    }]);
 
     assert!(client.try_pause().is_err());
 }
@@ -912,7 +909,7 @@ fn test_non_admin_cannot_unpause() {
     client.pause();
 
     use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
-    env.set_auths(&[MockAuth {
+    env.mock_auths(&[MockAuth {
         address: &non_admin,
         invoke: &MockAuthInvoke {
             contract: &contract_id,
@@ -920,8 +917,7 @@ fn test_non_admin_cannot_unpause() {
             args: ().into_val(&env),
             sub_invokes: &[],
         },
-    }
-    .into()]);
+    }]);
 
     assert!(client.try_unpause().is_err());
 }
@@ -976,7 +972,7 @@ fn test_non_admin_cannot_update_oracle() {
     client.initialize(&oracle, &admin, &token_addr);
 
     use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
-    env.set_auths(&[MockAuth {
+    env.mock_auths(&[MockAuth {
         address: &non_admin,
         invoke: &MockAuthInvoke {
             contract: &contract_id,
@@ -984,8 +980,7 @@ fn test_non_admin_cannot_update_oracle() {
             args: (new_oracle.clone(),).into_val(&env),
             sub_invokes: &[],
         },
-    }
-    .into()]);
+    }]);
 
     assert!(client.try_update_oracle(&new_oracle).is_err());
 }
@@ -1246,7 +1241,7 @@ fn test_non_admin_cannot_call_admin_functions() {
 
     use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
 
-    env.set_auths(&[MockAuth {
+    env.mock_auths(&[MockAuth {
         address: &non_admin,
         invoke: &MockAuthInvoke {
             contract: &contract_id,
@@ -1254,11 +1249,10 @@ fn test_non_admin_cannot_call_admin_functions() {
             args: ().into_val(&env),
             sub_invokes: &[],
         },
-    }
-    .into()]);
+    }]);
     assert!(client.try_pause().is_err());
 
-    env.set_auths(&[MockAuth {
+    env.mock_auths(&[MockAuth {
         address: &non_admin,
         invoke: &MockAuthInvoke {
             contract: &contract_id,
@@ -1266,11 +1260,10 @@ fn test_non_admin_cannot_call_admin_functions() {
             args: ().into_val(&env),
             sub_invokes: &[],
         },
-    }
-    .into()]);
+    }]);
     assert!(client.try_unpause().is_err());
 
-    env.set_auths(&[MockAuth {
+    env.mock_auths(&[MockAuth {
         address: &non_admin,
         invoke: &MockAuthInvoke {
             contract: &contract_id,
@@ -1278,8 +1271,7 @@ fn test_non_admin_cannot_call_admin_functions() {
             args: (new_oracle.clone(),).into_val(&env),
             sub_invokes: &[],
         },
-    }
-    .into()]);
+    }]);
     assert!(client.try_update_oracle(&new_oracle).is_err());
 }
 

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1071,12 +1071,12 @@ fn test_deposit_emits_event() {
         &String::from_str(&env, "deposit_ev"),
         &Platform::Lichess,
     );
-    
+
     // Test player1 deposit
     client.deposit(&id, &player1);
 
     client.deposit(&id, &player2);
-    
+
     let events = env.events().all();
     let deposit_topics = vec![
         &env,

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -425,8 +425,12 @@ fn test_submit_result_random_caller_is_unauthorized() {
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
-        &player1, &player2, &100, &token,
-        &String::from_str(&env, "random_caller"), &Platform::Lichess,
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "random_caller"),
+        &Platform::Lichess,
     );
     client.deposit(&id, &player1);
     client.deposit(&id, &player2);
@@ -476,7 +480,8 @@ fn test_submit_result_on_pending_match_fails() {
     );
 }
 
-// Issue #197: submit_result on an already Completed match should return InvalidState (no double-payout)
+// Issue #197: submit_result on an already Completed match should return
+// InvalidState (no double-payout)
 #[test]
 fn test_submit_result_on_completed_match_fails() {
     let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
@@ -1530,8 +1535,12 @@ fn test_submit_result_on_cancelled_match_no_deposit_fails() {
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
-        &player1, &player2, &100, &token,
-        &String::from_str(&env, "cancelled_result2"), &Platform::Lichess,
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "cancelled_result2"),
+        &Platform::Lichess,
     );
     client.cancel_match(&id, &player1);
 

--- a/contracts/escrow/src/tests_e2e.rs
+++ b/contracts/escrow/src/tests_e2e.rs
@@ -126,7 +126,8 @@ fn test_e2e_lifecycle_player1_wins() {
         .iter()
         .find(|(_, t, _)| *t == completed_topics)
         .expect("completed event not found");
-    let (ev_id, ev_winner, ev_payout): (u64, Winner, i128) = TryFromVal::try_from_val(&env, &data).unwrap();
+    let (ev_id, ev_winner, ev_payout): (u64, Winner, i128) =
+        TryFromVal::try_from_val(&env, &data).unwrap();
     assert_eq!(ev_id, match_id);
     assert_eq!(ev_winner, Winner::Player1);
     assert_eq!(ev_payout, stake * 2);
@@ -193,7 +194,8 @@ fn test_e2e_lifecycle_player2_wins() {
         .iter()
         .find(|(_, t, _)| *t == completed_topics)
         .expect("completed event not found");
-    let (ev_id, ev_winner, _ev_payout): (u64, Winner, i128) = TryFromVal::try_from_val(&env, &data).unwrap();
+    let (ev_id, ev_winner, _ev_payout): (u64, Winner, i128) =
+        TryFromVal::try_from_val(&env, &data).unwrap();
     assert_eq!(ev_id, match_id);
     assert_eq!(ev_winner, Winner::Player2);
 
@@ -257,7 +259,8 @@ fn test_e2e_lifecycle_draw() {
         .iter()
         .find(|(_, t, _)| *t == completed_topics)
         .expect("completed event not found");
-    let (ev_id, ev_winner, _ev_payout): (u64, Winner, i128) = TryFromVal::try_from_val(&env, &data).unwrap();
+    let (ev_id, ev_winner, _ev_payout): (u64, Winner, i128) =
+        TryFromVal::try_from_val(&env, &data).unwrap();
     assert_eq!(ev_id, match_id);
     assert_eq!(ev_winner, Winner::Draw);
 
@@ -622,8 +625,13 @@ fn test_e2e_event_sequence_full_lifecycle() {
         .iter()
         .find(|(_, t, _)| *t == created_topics)
         .expect("created event not found");
-    let (ev_id, ev_p1, ev_p2, ev_stake, _ev_game_id): (u64, Address, Address, i128, soroban_sdk::String) =
-        TryFromVal::try_from_val(&env, &created_data).unwrap();
+    let (ev_id, ev_p1, ev_p2, ev_stake, _ev_game_id): (
+        u64,
+        Address,
+        Address,
+        i128,
+        soroban_sdk::String,
+    ) = TryFromVal::try_from_val(&env, &created_data).unwrap();
     assert_eq!(ev_id, match_id);
     assert_eq!(ev_p1, player1);
     assert_eq!(ev_p2, player2);

--- a/contracts/escrow/src/tests_e2e.rs
+++ b/contracts/escrow/src/tests_e2e.rs
@@ -12,6 +12,8 @@
 //!   - All expected events are emitted with correct data
 //!   - Error paths: wrong oracle, game_id mismatch, invalid state re-entry
 
+extern crate std;
+
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Events},
@@ -191,7 +193,7 @@ fn test_e2e_lifecycle_player2_wins() {
         .iter()
         .find(|(_, t, _)| *t == completed_topics)
         .expect("completed event not found");
-    let (ev_id, ev_winner): (u64, Winner) = TryFromVal::try_from_val(&env, &data).unwrap();
+    let (ev_id, ev_winner, _ev_payout): (u64, Winner, i128) = TryFromVal::try_from_val(&env, &data).unwrap();
     assert_eq!(ev_id, match_id);
     assert_eq!(ev_winner, Winner::Player2);
 
@@ -255,7 +257,7 @@ fn test_e2e_lifecycle_draw() {
         .iter()
         .find(|(_, t, _)| *t == completed_topics)
         .expect("completed event not found");
-    let (ev_id, ev_winner): (u64, Winner) = TryFromVal::try_from_val(&env, &data).unwrap();
+    let (ev_id, ev_winner, _ev_payout): (u64, Winner, i128) = TryFromVal::try_from_val(&env, &data).unwrap();
     assert_eq!(ev_id, match_id);
     assert_eq!(ev_winner, Winner::Draw);
 
@@ -620,7 +622,7 @@ fn test_e2e_event_sequence_full_lifecycle() {
         .iter()
         .find(|(_, t, _)| *t == created_topics)
         .expect("created event not found");
-    let (ev_id, ev_p1, ev_p2, ev_stake): (u64, Address, Address, i128) =
+    let (ev_id, ev_p1, ev_p2, ev_stake, _ev_game_id): (u64, Address, Address, i128, soroban_sdk::String) =
         TryFromVal::try_from_val(&env, &created_data).unwrap();
     assert_eq!(ev_id, match_id);
     assert_eq!(ev_p1, player1);
@@ -667,7 +669,7 @@ fn test_e2e_event_sequence_full_lifecycle() {
         .iter()
         .find(|(_, t, _)| *t == completed_topics)
         .expect("completed event not found");
-    let (ev_completed_id, ev_winner): (u64, Winner) =
+    let (ev_completed_id, ev_winner, _ev_payout): (u64, Winner, i128) =
         TryFromVal::try_from_val(&env, &completed_data).unwrap();
     assert_eq!(ev_completed_id, match_id);
     assert_eq!(ev_winner, Winner::Player1);

--- a/contracts/oracle/src/errors.rs
+++ b/contracts/oracle/src/errors.rs
@@ -39,16 +39,33 @@ pub enum Error {
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Error::Unauthorized =>
-                write!(f, "[E001] Unauthorized: caller is not the registered oracle admin"),
-            Error::AlreadySubmitted =>
-                write!(f, "[E002] AlreadySubmitted: a result has already been recorded for this match_id"),
-            Error::ResultNotFound =>
-                write!(f, "[E003] ResultNotFound: no result has been submitted for this match_id"),
-            Error::AlreadyInitialized =>
-                write!(f, "[E004] AlreadyInitialized: contract has already been initialized"),
-            Error::InvalidGameId =>
-                write!(f, "[E005] InvalidGameId: game_id is empty or exceeds the 64-byte limit"),
+            Error::Unauthorized => {
+                write!(f, "[E001] Unauthorized: caller is not the registered oracle admin")
+            }
+            Error::AlreadySubmitted => {
+                write!(
+                    f,
+                    "[E002] AlreadySubmitted: a result has already been recorded for this match_id"
+                )
+            }
+            Error::ResultNotFound => {
+                write!(
+                    f,
+                    "[E003] ResultNotFound: no result has been submitted for this match_id"
+                )
+            }
+            Error::AlreadyInitialized => {
+                write!(
+                    f,
+                    "[E004] AlreadyInitialized: contract has already been initialized"
+                )
+            }
+            Error::InvalidGameId => {
+                write!(
+                    f,
+                    "[E005] InvalidGameId: game_id is empty or exceeds the 64-byte limit"
+                )
+            }
         }
     }
 }

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -183,7 +183,7 @@ mod tests {
         client.initialize(&admin);
 
         use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
-        env.set_auths(&[MockAuth {
+        env.mock_auths(&[MockAuth {
             address: &non_admin,
             invoke: &MockAuthInvoke {
                 contract: &contract_id,
@@ -196,8 +196,7 @@ mod tests {
                     .into_val(&env),
                 sub_invokes: &[],
             },
-        }
-        .into()]);
+        }]);
 
         assert!(client
             .try_submit_result(
@@ -281,7 +280,7 @@ mod tests {
         client.initialize(&admin);
 
         use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
-        env.set_auths(&[MockAuth {
+        env.mock_auths(&[MockAuth {
             address: &non_admin,
             invoke: &MockAuthInvoke {
                 contract: &contract_id,
@@ -289,8 +288,7 @@ mod tests {
                 args: (new_admin.clone(),).into_val(&env),
                 sub_invokes: &[],
             },
-        }
-        .into()]);
+        }]);
 
         assert!(client.try_transfer_admin(&new_admin).is_err());
     }

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -317,11 +317,6 @@ mod tests {
     /// for every possible `MatchResult` variant.
     #[test]
     fn test_oracle_submit_result_emits_event() {
-        let result_topic = vec![
-            &Env::default(), // placeholder; real env built per case
-        ];
-        let _ = result_topic; // silence unused warning; real assertions below
-
         let cases: &[(u64, MatchResult)] = &[
             (1u64, MatchResult::Player1Wins),
             (2u64, MatchResult::Player2Wins),


### PR DESCRIPTION
- Pin soroban-sdk to 22.0.11 to match Cargo.lock (fixes --locked Test failure)
- Replace all env.set_auths(...into()) with env.mock_auths(...) in escrow and oracle tests (fixes Clippy and Test failures — set_auths requires real crypto signatures in soroban-sdk 22.x; mock_auths is the correct test API)
- Affects: test_non_admin_cannot_pause, test_non_admin_cannot_unpause, test_non_admin_cannot_update_oracle, test_non_admin_cannot_call_admin_functions, test_cancel_with_both_deposits_requires_both_auth, test_submit_result_random_caller_is_unauthorized, test_non_admin_cannot_submit_result, test_non_admin_cannot_transfer_admin