### PR TITLE
feat(escrow): add emergency_drain for critical exploit recovery (#912)

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -86,4 +86,7 @@ pub enum Error {
 
     /// [E017] Deposit rejected because the match has already completed.
     MatchCompleted = 17,
+
+    /// [E018] emergency_drain requires the contract to be paused first.
+    NotPaused = 18,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -423,6 +423,54 @@ impl EscrowContract {
         Ok(())
     }
 
+    /// Drain all token holdings to a safe address — admin only, requires contract to be paused.
+    ///
+    /// This is an emergency recovery function for critical exploit scenarios. It transfers
+    /// the entire contract token balance to `to` and emits an `admin:emergency_drain` event.
+    ///
+    /// # Future enhancements
+    /// - **Time-lock**: require a delay (e.g., 24 h) between `pause()` and `emergency_drain()`
+    ///   so players can challenge a malicious admin action.
+    /// - **Multi-sig**: require M-of-N admin signatures to prevent a single compromised key
+    ///   from draining funds.
+    pub fn emergency_drain(env: Env, to: Address, caller: Address) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+
+        if caller != admin {
+            return Err(Error::Unauthorized);
+        }
+        caller.require_auth();
+
+        if !Self::is_paused(&env) {
+            return Err(Error::NotPaused);
+        }
+
+        let token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Token)
+            .ok_or(Error::Unauthorized)?;
+
+        let client = token::Client::new(&env, &token);
+        let contract = env.current_contract_address();
+        let balance = client.balance(&contract);
+
+        if balance > 0 {
+            client.transfer(&contract, &to, &balance);
+        }
+
+        env.events().publish(
+            (Symbol::new(&env, "admin"), symbol_short!("drain")),
+            (balance, to, admin),
+        );
+
+        Ok(())
+    }
+
     /// Read a match by ID.
     pub fn get_match(env: Env, match_id: u64) -> Result<Match, Error> {
         env.storage()

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1649,3 +1649,73 @@ fn test_cancel_match_refunds_only_player1_when_only_player1_deposited() {
     // Match must be in Cancelled state
     assert_eq!(client.get_match(&id).state, MatchState::Cancelled);
 }
+
+// Issue #912: emergency_drain — success, unpaused guard, non-admin guard
+
+#[test]
+fn test_emergency_drain_succeeds_when_paused() {
+    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+
+    // Fund the escrow with two deposits
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "drain_test"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    assert_eq!(token_client.balance(&contract_id), 200);
+
+    client.pause();
+
+    let safe = Address::generate(&env);
+    client.emergency_drain(&safe, &admin);
+
+    assert_eq!(token_client.balance(&contract_id), 0);
+    assert_eq!(token_client.balance(&safe), 200);
+
+    // Verify event
+    let events = env.events().all();
+    let drain_topics = vec![
+        &env,
+        Symbol::new(&env, "admin").into_val(&env),
+        symbol_short!("drain").into_val(&env),
+    ];
+    let matched = events.iter().find(|(_, t, _)| *t == drain_topics);
+    assert!(matched.is_some());
+    let (_, _, data) = matched.unwrap();
+    let (ev_amount, ev_to, ev_admin): (i128, Address, Address) =
+        TryFromVal::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev_amount, 200);
+    assert_eq!(ev_to, safe);
+    assert_eq!(ev_admin, admin);
+}
+
+#[test]
+fn test_emergency_drain_fails_when_not_paused() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let safe = Address::generate(&env);
+    assert_eq!(
+        client.try_emergency_drain(&safe, &admin),
+        Err(Ok(Error::NotPaused))
+    );
+}
+
+#[test]
+fn test_emergency_drain_fails_for_non_admin() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    client.pause();
+    let non_admin = Address::generate(&env);
+    let safe = Address::generate(&env);
+    assert_eq!(
+        client.try_emergency_drain(&safe, &non_admin),
+        Err(Ok(Error::Unauthorized))
+    );
+}

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,121 @@
+# Emergency Drain Runbook
+
+Procedure for using `emergency_drain` to recover funds from the escrow contract during a critical exploit.
+
+## When to use this
+
+Use `emergency_drain` only when:
+
+- An active exploit is draining or threatening to drain the escrow contract, **and**
+- There is no time to wait for match resolution via the oracle.
+
+Do **not** use it for routine administration. The function transfers every token the contract holds to a single address in one transaction, bypassing all per-match accounting.
+
+## Prerequisites
+
+- The **admin private key** for the deployed contract.
+- A **safe cold-wallet address** (`SAFE_ADDRESS`) controlled offline or by multi-sig, never the admin hot wallet.
+- The **Stellar CLI** (`stellar`) installed and configured for the target network.
+- The **contract address** (`CONTRACT_ADDRESS`) of the deployed escrow contract.
+
+## Step-by-step
+
+### 1. Confirm the exploit
+
+Before draining, verify the threat is real:
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ADDRESS \
+  --network $NETWORK \
+  -- get_match --match_id <id>
+```
+
+Check unusual state transitions, repeated results submitted for the same match, or the contract balance dropping unexpectedly.
+
+### 2. Pause the contract
+
+Pausing blocks `create_match`, `deposit`, and `submit_result` immediately.
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ADDRESS \
+  --source $ADMIN_SECRET_KEY \
+  --network $NETWORK \
+  -- pause
+```
+
+Confirm the contract is paused before proceeding. Any subsequent call to `create_match` or `deposit` should return `Error::ContractPaused (9)`.
+
+### 3. Drain to the safe address
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ADDRESS \
+  --source $ADMIN_SECRET_KEY \
+  --network $NETWORK \
+  -- emergency_drain \
+     --to $SAFE_ADDRESS \
+     --caller $ADMIN_ADDRESS
+```
+
+`emergency_drain` will:
+
+1. Verify `caller` is the registered admin.
+2. Verify the contract is paused (returns `Error::NotPaused (18)` otherwise).
+3. Query the contract's token balance.
+4. Transfer the full balance to `to`.
+5. Emit an `admin:drain` event recording `(amount, to, admin)`.
+
+If the balance is zero the call succeeds silently (no transfer is attempted).
+
+### 4. Verify the transfer
+
+```bash
+stellar contract invoke \
+  --id $TOKEN_ADDRESS \
+  --network $NETWORK \
+  -- balance --id $SAFE_ADDRESS
+```
+
+The safe address should hold the drained amount. The contract balance should be zero.
+
+### 5. Record the incident
+
+Document:
+
+- UTC timestamp of `pause()` and `emergency_drain()`.
+- Transaction hashes for both calls.
+- Amount drained and destination address.
+- Root cause (if known at time of drain).
+
+Keep this in an incident log separate from the repository.
+
+### 6. Post-incident
+
+After the exploit is fully understood and patched:
+
+- Deploy a new contract version.
+- Redistribute funds from `SAFE_ADDRESS` to affected players based on the match state at time of pause.
+- Unpause or retire the old contract as appropriate.
+
+```bash
+# Unpause (only if continuing to use the same contract)
+stellar contract invoke \
+  --id $CONTRACT_ADDRESS \
+  --source $ADMIN_SECRET_KEY \
+  --network $NETWORK \
+  -- unpause
+```
+
+## Error reference
+
+| Error | Code | Meaning |
+|-------|------|---------|
+| `NotPaused` | 18 | `emergency_drain` called without pausing first |
+| `Unauthorized` | 4 | `caller` is not the registered admin |
+
+## Future enhancements
+
+- **Time-lock**: enforce a minimum delay (e.g., 24 h) between `pause()` and `emergency_drain()` so players can challenge an illegitimate drain before it executes.
+- **Multi-sig**: require M-of-N admin key signatures so no single compromised key can drain the contract unilaterally.


### PR DESCRIPTION
 closes #912 
- Add emergency_drain(to, caller) callable by admin when paused
- Require is_paused() == true, else return Error::NotPaused (18)
- Transfer full contract token balance to safe address
- Emit admin:drain event with amount, destination, and admin
- Add NotPaused = 18 to Error enum
- Add 3 unit tests: success, unpaused guard, non-admin guard
- Add docs/runbook.md with step-by-step emergency procedure
- Note time-lock and multi-sig as future enhancements