### PR TITLE
feat(ci): add frontend job with type-check and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,33 @@ jobs:
 
       - name: Build contracts
         run: cargo build --release --target wasm32-unknown-unknown
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        with:
+          path: apps/frontend/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('apps/frontend/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: tsc --noEmit
+
+      - name: Run tests
+        run: vitest run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,16 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
         with:
           toolchain: 1.88.0
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: |
             ~/.cargo/registry
@@ -43,17 +43,17 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
         with:
           toolchain: 1.88.0
           targets: wasm32-unknown-unknown
           components: clippy
 
       - name: Cache cargo
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: |
             ~/.cargo/registry
@@ -69,10 +69,10 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
         with:
           toolchain: 1.88.0
           components: rustfmt
@@ -84,16 +84,16 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
         with:
           toolchain: 1.88.0
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: |
             ~/.cargo/registry
@@ -112,15 +112,15 @@ jobs:
       run:
         working-directory: apps/frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
       - name: Cache node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: apps/frontend/node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('apps/frontend/package-lock.json') }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,32 @@ Before submitting a PR, confirm:
 - [ ] New behaviour is covered by tests
 - [ ] No secrets or `.env` files are committed
 
+## CI Security: Action Pinning
+
+All third-party GitHub Actions used in `.github/workflows/*.yml` **must** be pinned to their full immutable commit SHA, not to a version tag. This prevents supply-chain attacks where a tag is silently moved to a malicious commit.
+
+```
+# ✅ Correct — pinned by SHA with a version comment
+- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+# ❌ Incorrect — mutable tag reference
+- uses: actions/checkout@v4
+```
+
+When adding or updating an action:
+
+1. Resolve the SHA by querying the upstream repository.
+2. Use the full 40-character SHA after `@`.
+3. Append the original version as a trailing comment (e.g. `# v4`).
+
+To resolve the SHA for a tagged action:
+
+```bash
+git ls-remote https://github.com/<owner>/<repo>.git refs/tags/<tag>
+```
+
+---
+
 ## Reporting Issues
 
 Open a GitHub issue with:

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -22,7 +22,7 @@ export function App() {
   };
 
   return (
-    <main style={{ padding: '2rem', minHeight: '100vh', background: '#f5f5f5' }}>
+    <main className="bg-gray-100" style={{ padding: '2rem', minHeight: '100vh' }}>
       <ClaimBurn
         walletState={walletState}
         onConnect={connect}

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { ClaimBurn } from './components/claim-burn';
+import { NetworkBadge } from './components/NetworkBadge';
 import { useStellarWallet } from './hooks/useStellarWallet';
 import type { WalletStatus } from './types';
 
@@ -23,6 +24,9 @@ export function App() {
 
   return (
     <main className="bg-gray-100" style={{ padding: '2rem', minHeight: '100vh' }}>
+      <div className="mb-4">
+        <NetworkBadge />
+      </div>
       <ClaimBurn
         walletState={walletState}
         onConnect={connect}

--- a/apps/frontend/src/components/NetworkBadge.tsx
+++ b/apps/frontend/src/components/NetworkBadge.tsx
@@ -1,0 +1,33 @@
+const NETWORK_LABELS: Record<string, string> = {
+  mainnet: 'Mainnet',
+  testnet: 'Testnet',
+  futurenet: 'Futurenet',
+  standalone: 'Standalone',
+};
+
+const NETWORK_COLORS: Record<string, string> = {
+  mainnet: 'bg-green-600',
+  testnet: 'bg-amber-500',
+  futurenet: 'bg-orange-500',
+  standalone: 'bg-gray-400',
+};
+
+interface NetworkBadgeProps {
+  network?: string;
+}
+
+export function NetworkBadge({ network }: NetworkBadgeProps) {
+  const net = network ?? (import.meta.env.VITE_STELLAR_NETWORK ?? 'testnet');
+  const label = NETWORK_LABELS[net] ?? net;
+  const color = NETWORK_COLORS[net] ?? 'bg-gray-400';
+
+  return (
+    <span
+      className={`inline-block rounded px-2 py-0.5 text-xs font-semibold uppercase tracking-wide ${color} text-white`}
+      data-testid="network-badge"
+      data-network={net}
+    >
+      {label}
+    </span>
+  );
+}

--- a/apps/frontend/tests/NetworkBadge.test.tsx
+++ b/apps/frontend/tests/NetworkBadge.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { NetworkBadge } from '../src/components/NetworkBadge';
+
+describe('NetworkBadge', () => {
+  it('shows Mainnet with green background', () => {
+    render(<NetworkBadge network="mainnet" />);
+    const badge = screen.getByTestId('network-badge');
+    expect(badge).toHaveTextContent('Mainnet');
+    expect(badge).toHaveAttribute('data-network', 'mainnet');
+    expect(badge.className).toContain('bg-green-600');
+  });
+
+  it('shows Testnet with amber background', () => {
+    render(<NetworkBadge network="testnet" />);
+    const badge = screen.getByTestId('network-badge');
+    expect(badge).toHaveTextContent('Testnet');
+    expect(badge).toHaveAttribute('data-network', 'testnet');
+    expect(badge.className).toContain('bg-amber-500');
+  });
+
+  it('shows Futurenet with orange background', () => {
+    render(<NetworkBadge network="futurenet" />);
+    const badge = screen.getByTestId('network-badge');
+    expect(badge).toHaveTextContent('Futurenet');
+    expect(badge).toHaveAttribute('data-network', 'futurenet');
+    expect(badge.className).toContain('bg-orange-500');
+  });
+
+  it('shows Standalone with grey background', () => {
+    render(<NetworkBadge network="standalone" />);
+    const badge = screen.getByTestId('network-badge');
+    expect(badge).toHaveTextContent('Standalone');
+    expect(badge).toHaveAttribute('data-network', 'standalone');
+    expect(badge.className).toContain('bg-gray-400');
+  });
+
+  it('shows unknown network as-is with grey background', () => {
+    render(<NetworkBadge network="unknown" />);
+    const badge = screen.getByTestId('network-badge');
+    expect(badge).toHaveTextContent('unknown');
+    expect(badge).toHaveAttribute('data-network', 'unknown');
+    expect(badge.className).toContain('bg-gray-400');
+  });
+
+  it('defaults to testnet when no network prop given', () => {
+    render(<NetworkBadge />);
+    const badge = screen.getByTestId('network-badge');
+    expect(badge).toHaveAttribute('data-network');
+  });
+});


### PR DESCRIPTION
Closes #880 
Closes #881 
Closes #882 
Closes #883 

Adds a frontend CI job that runs `tsc --noEmit` and `vitest run` with Node.js 20 and dependency caching, preventing TypeScript errors and failing tests from reaching master.