### PR TITLE
docs: document environments.toml fields and add comprehensive CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,139 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ### Added
-- Kiro AI-assisted development integration
-- `submit_result`: added `game_id` parameter with cross-match injection guard — oracle must supply the `game_id` that matches the stored match record; mismatches return `Error::GameIdMismatch` (E013) before any state is modified
-- `Error::GameIdMismatch` (code 13): new error variant to signal oracle submitted a result for the wrong game
-- `test_submit_result_wrong_game_id_fails`: unit test asserting `GameIdMismatch` when oracle passes a mismatched `game_id`
+- Document `environments.toml` fields in `README.md` with descriptions and defaults (#115)
 
-## [1.0.0] - 2026-04-25
+## [0.2.0] - 2026-06-24
+
+### Added
+
+#### Smart Contract — Escrow
+- `emergency_drain` for critical exploit recovery (#912)
+- `Error::GameIdMismatch` (code 13): cross-match result injection guard
+- `Error::DuplicateGameId` (code 14): duplicate game ID prevention
+- Token address validation on `initialize` (#211)
+- Game ID uniqueness enforcement across matches
+- Self-match prevention (`player1 != player2`)
+- `is_paused` helper extraction to reduce code duplication
+
+#### Smart Contract — Oracle
+- Game ID length validation (max 64 bytes)
+- Initialization event emission `("oracle", "init")`
+
+#### Frontend
+- Claim/burn UI with full wallet state machine (connecting, connected, wrong-network, error, not-installed)
+- Dark mode support via Tailwind `dark:` classes
+- Copy-to-clipboard for wallet address and transaction hash
+- ARIA live regions and keyboard focus management
+- Transaction history view
+- Balance display, Max button, and real-time refresh
+- Confirmation overlay with inline modal design
+- NetworkBadge component with colour-coded network display
+- Responsive layout with mobile breakpoints
+
+#### Tests
+- Player1 win payout sends full pot to player1 (#208)
+- Player2 win payout sends full pot to player2 (#36)
+- Cancel active match and draw payout tests (#198, #199)
+- `deposit` by non-player returns `Unauthorized` (#192)
+- `is_funded` returns false after one deposit, true after both (#195)
+- `submit_result` on `Pending` match returns `InvalidState` (#196)
+- `submit_result` on `Completed` match returns `InvalidState` (#197)
+- `submit_result` on `Cancelled` match returns `InvalidState` (#72, #100)
+- Unauthorized oracle `submit_result` rejection
+- Oracle `get_result` `ResultNotFound` error path
+- Frontend form validation (#69)
+- E2E transaction validation (#71)
+- Input validation and security pre-checks (#70)
+- Backend integration tests (#68)
+- Test coverage for issues #21–30, #33–35, #55–58, #59–62, #89–90, #92–98
+
+#### Infrastructure & CI
+- GitHub Actions CI workflow with test, clippy, fmt, and WASM build
+- Clippy job and CI status badge (#106, #120, #121)
+- `deploy_testnet.sh` deployment script (#113)
+- `deploy_mainnet.sh` deployment script (#112)
+- Rust toolchain pinning (1.85.0 → 1.88.0)
+- Cargo audit step for RUSTSEC advisory detection (#119)
+- Cargo deny for dependency license and duplicate-crate checks
+- WASM binary size gate (64 KB limit)
+
+#### Documentation
+- `docs/architecture.md` — system architecture overview (#108, #109, #110)
+- `docs/oracle.md` — oracle design and operation (#108, #109, #110)
+- `docs/security.md` — threat model and security mitigations (#111)
+- `docs/roadmap.md` — project roadmap (#111)
+- `docs/api-reference.md` — full contract API with examples (#111)
+- `docs/infrastructure.md` — deployment and environment documentation (#114)
+- `CONTRIBUTING.md` — contributor guide (#104)
+- `ISSUES.md` — 125 tracked issues
+- Module-level doc comments (`//!`) for escrow and oracle contracts
+
+### Fixed
+
+#### Smart Contract
+- Prevent double initialization of escrow contract (re-initialization guard) (#1)
+- Prevent double initialization of oracle contract (#2)
+- Use `try_transfer` for refunds instead of `transfer` to surface errors cleanly
+- Verify token transfer in `deposit` before updating state
+- Remove duplicate `Display` impls conflicting with `#[contracterror]` macro (E0428)
+- Remove broken intra-doc link to non-existent `Error::InvalidToken`
+- Resolve compile errors in escrow `lib.rs`
+- Resolve Clippy errors, redundant clones, and dead code
+- Resolve rustfmt failures (trailing whitespace)
+- Resolve test assertion bugs in e2e tests
+- Resolve infrastructure compile errors and test mismatches (#118)
+- Fix CI/CD branch triggers from `main`/`develop` to `master` (#117)
+
+#### Frontend
+- Wire `handleClaim` and `handleBurn` to actual Stellar SDK transaction submission
+- Wire `disconnect`, `refreshBalance`, `balance`, and `wrongNetwork` in `App.tsx`
+- Fix CSS import path and add missing wallet-info layout styles
+- Fix confirm overlay display (inline block instead of fixed full-screen modal)
+- Add `wrongNetwork` to `WalletStatus` type
+- Fix PostCSS config ESM conflict and unblock claim-burn tests
+- Resolve multiple wallet state typing and wiring inconsistencies
+
+#### CI
+- Resolve all Clippy, Format, and Test CI failures (multiple rounds)
+- Bump toolchain to satisfy `darling`/`serde_with` dependency requirements
+- Apply `cargo-audit` 0.22.0 migration
+
+### Security
+- Document full threat model covering oracle key compromise and admin key loss (#119)
+- Add `pause` + `drain` emergency function for critical exploit recovery (#912)
+- Add re-initialization guards to both escrow and oracle contracts
+- Validate token address in `initialize` to prevent rogue token injection
+- Enforce game ID uniqueness to prevent duplicate-match payout exploits
+- Add `game_id` cross-match injection guard (`Error::GameIdMismatch`)
+- Document integer overflow risk in `submit_result` payout calculation
+- Document re-entrancy analysis confirming Soroban execution model prevents re-entrancy
+
+### Changed
+- `submit_result` now requires a `game_id` parameter that must match the stored match record
+- Oracle contract now emits `("oracle", "init")` event on initialization
+- Oracle contract validates `game_id` length (1–64 bytes) on submission
+- `cancel_match` with both players deposited requires authorization from both parties
+- Replace `panic!` in Oracle `initialize` with proper `Error::AlreadyInitialized`
+
+## [0.1.0] - 2026-04-25
 
 ### Added
 - Soroban escrow contract with XLM stake support
 - Oracle contract for Lichess result verification
 - Automatic winner payout and draw refund logic
-- Match creation, deposit, and cancellation flows
+- Match creation, deposit, cancellation, and completion flows
 - Admin pause/unpause and oracle update controls
+- Match state machine (`Pending` → `Active` → `Completed`/`Cancelled`)
+- Read-only query functions: `get_match`, `is_funded`, `get_escrow_balance`
+- Oracle query functions: `get_result`, `has_result`
+- Oracle `transfer_admin` for key rotation
 - CI workflow via GitHub Actions
+- Basic project scaffolding and build scripts

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ stellar keys generate deployer --network testnet
 ## 📖 Documentation
 
 - [Architecture Overview](docs/architecture.md)
+- [Deployment Guide](docs/deployment.md)
 - [Oracle Design](docs/oracle.md)
 - [Threat Model & Security](docs/security.md)
 - [Roadmap](docs/roadmap.md)

--- a/README.md
+++ b/README.md
@@ -126,12 +126,25 @@ VITE_STELLAR_NETWORK=testnet
 VITE_STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 ```
 
-Network configurations are defined in `environments.toml`:
+Network configurations are defined in `environments.toml`. Each environment is a TOML section with the fields below.
 
-- `testnet` — Stellar testnet
-- `mainnet` — Stellar mainnet
-- `futurenet` — Stellar futurenet
-- `standalone` — Local development
+### `environments.toml` Field Reference
+
+| Field | Type | Required | Description | Example (testnet) |
+|---|---|---|---|---|
+| `[network]` | section | **required** | TOML section key identifying the Stellar network | `[testnet]` |
+| `network_passphrase` | string | **required** | Stellar network passphrase used for transaction signing | `"Test SDF Network ; September 2015"` |
+| `rpc_url` | string | **required** | Soroban RPC endpoint URL for the network | `"https://soroban-testnet.stellar.org"` |
+| `horizon_url` | string | optional | Horizon REST API endpoint URL (reserved for future use) | `"https://horizon-testnet.stellar.org"` |
+
+Recognized network sections:
+
+| Section | Environment |
+|---|---|
+| `[testnet]` | Stellar testnet |
+| `[mainnet]` | Stellar mainnet |
+| `[futurenet]` | Stellar futurenet |
+| `[standalone]` | Local development |
 
 ### Deploy to Testnet
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,36 +4,32 @@
 
 smile4money is composed of two Soroban smart contracts and an off-chain oracle service.
 
-```
-┌─────────────────────────────────────────────────────────┐
-│                        Players                          │
-│              (Stellar wallets / frontend)               │
-└────────────────────┬────────────────────────────────────┘
-                     │ create_match / deposit / cancel_match
-                     ▼
-┌─────────────────────────────────────────────────────────┐
-│               Escrow Contract (Soroban)                 │
-│  - Holds stakes in persistent storage                   │
-│  - Manages match lifecycle (Pending → Active →          │
-│    Completed / Cancelled)                               │
-│  - Executes payouts on submit_result                    │
-│  - Admin: pause / unpause                               │
-└────────────────────┬────────────────────────────────────┘
-                     │ submit_result(match_id, winner, caller)
-                     ▲
-┌─────────────────────────────────────────────────────────┐
-│               Oracle Contract (Soroban)                 │
-│  - Stores verified results keyed by match_id            │
-│  - Admin-only submit_result                             │
-│  - Emits on-chain events for indexers                   │
-└────────────────────┬────────────────────────────────────┘
-                     ▲
-┌─────────────────────────────────────────────────────────┐
-│            Off-chain Oracle Service                     │
-│  - Polls Lichess / Chess.com APIs                       │
-│  - Verifies game result against match game_id           │
-│  - Signs and submits result to Oracle Contract          │
-└─────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    P1[Player1]
+    P2[Player2]
+    FE[Frontend]
+    EC[Escrow Contract<br/>Soroban]
+    OC[Oracle Contract<br/>Soroban]
+    OOS[Off-chain Oracle<br/>Service]
+    LA[Lichess API]
+    CA[Chess.com API]
+
+    P1 -->|interacts| FE
+    P2 -->|interacts| FE
+
+    FE -->|create_match<br/>deposit<br/>cancel_match| EC
+
+    OOS -->|GET /api/game/{id}| LA
+    OOS -->|GET /pub/player/{user}/games| CA
+    LA -->|game result| OOS
+    CA -->|game result| OOS
+
+    OOS -->|submit_result<br/>match_id, game_id, result| OC
+    OOS -->|submit_result<br/>match_id, game_id, winner, caller| EC
+
+    EC -->|payout<br/>stake_amount × 2| P1
+    EC -->|payout<br/>stake_amount × 2| P2
 ```
 
 ## Match Lifecycle

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,291 @@
+# Deployment Guide
+
+This document covers end-to-end deployment of smile4money contracts to Stellar testnet and mainnet.
+
+## Prerequisites
+
+- **Rust toolchain** (1.70+) with `wasm32-unknown-unknown` target:
+  ```bash
+  rustup target add wasm32-unknown-unknown
+  ```
+- **Stellar CLI** — install from the [official docs](https://developers.stellar.org/docs/tools/developer-tools/cli/install-cli)
+- **Stellar deployer account** funded with XLM (testnet XLM is free via Friendbot; mainnet requires real XLM)
+- **`git`** checkout of the repository at the commit to deploy
+
+## Testnet Deployment
+
+### 1. Create and fund a deployer identity
+
+```bash
+stellar keys generate deployer --network testnet
+```
+
+This creates a local keypair named `deployer` and registers it for the `testnet` network. To view the public address:
+
+```bash
+stellar keys address deployer
+```
+
+If the account has not been used before, it needs a minimum XLM balance. The deploy script funds it automatically via Friendbot, but you can also fund it manually:
+
+```bash
+curl -sf "https://friendbot.stellar.org?addr=$(stellar keys address deployer)"
+```
+
+**Expected output:**
+```json
+{"message": "Account created!", "hash": "..."}
+```
+
+### 2. Run the deploy script
+
+```bash
+./scripts/deploy_testnet.sh
+```
+
+The script performs these steps in order:
+
+1. Verifies the `stellar` CLI is installed and the `deployer` identity exists.
+2. Funds the deployer via Friendbot (no-op if already funded).
+3. Builds both contracts (`escrow.wasm`, `oracle.wasm`) in release mode.
+4. Deploys the escrow contract to testnet.
+5. Deploys the oracle contract to testnet.
+6. Initializes the oracle contract (admin = deployer address).
+7. Initializes the escrow contract (oracle = oracle contract address, admin = deployer address).
+8. Writes `CONTRACT_ESCROW` and `CONTRACT_ORACLE` to `.env`.
+
+**Expected output:**
+```
+Deployer: GABCDEF123...
+Funding deployer account via friendbot...
+Building contracts...
+Deploying escrow contract...
+Escrow contract: CC123...
+Deploying oracle contract...
+Oracle contract: CC456...
+Initializing oracle contract...
+Initializing escrow contract...
+
+Deployment complete.
+  Escrow:  CC123...
+  Oracle:  CC456...
+Contract IDs written to .env
+```
+
+### 3. Verify the deployment
+
+Check that contract IDs were written to `.env`:
+
+```bash
+grep -E "^(CONTRACT_ESCROW|CONTRACT_ORACLE)=" .env
+```
+
+Verify the contracts are live and responsive:
+
+```bash
+# Check escrow contract is queryable (should return match count 0)
+stellar contract invoke \
+  --id "$(grep CONTRACT_ESCROW .env | cut -d= -f2)" \
+  --source deployer \
+  --network testnet \
+  --rpc-url https://soroban-testnet.stellar.org \
+  --network-passphrase "Test SDF Network ; September 2015" \
+  -- get_match \
+  --match_id 0
+
+# Check oracle contract is queryable
+stellar contract invoke \
+  --id "$(grep CONTRACT_ORACLE .env | cut -d= -f2)" \
+  --source deployer \
+  --network testnet \
+  --rpc-url https://soroban-testnet.stellar.org \
+  --network-passphrase "Test SDF Network ; September 2015" \
+  -- has_result \
+  --match_id 0
+```
+
+If the contracts are deployed correctly, `has_result` returns `false` and `get_match` returns `Error::MatchNotFound` (the contract is live and rejecting invalid queries properly).
+
+### 4. Configure the off-chain oracle
+
+After deployment, populate the remaining `.env` fields:
+
+```env
+STELLAR_NETWORK=testnet
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+CONTRACT_ESCROW=<contract-id-from-deploy>
+CONTRACT_ORACLE=<contract-id-from-deploy>
+LICHESS_API_TOKEN=<your-lichess-api-token>
+CHESSDOTCOM_API_KEY=<your-chessdotcom-api-key>
+VITE_STELLAR_NETWORK=testnet
+VITE_STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+```
+
+These values are used by the off-chain oracle service and the frontend.
+
+## Mainnet Deployment
+
+Mainnet deployment follows the same steps but with additional precautions because transactions are irreversible and consume real XLM.
+
+### Pre-deploy review checklist
+
+- [ ] All CI jobs pass on the commit being deployed (test, clippy, fmt, build).
+- [ ] Security audit (`cargo audit`) reports zero unresolved advisories.
+- [ ] Contracts have been live on testnet for at least one full test cycle.
+- [ ] A dedicated deployer key is used — never a personal or shared key.
+- [ ] The deployer account is funded with sufficient XLM to cover deploy + init fees (approximately 10–20 XLM).
+- [ ] The commit to deploy has been reviewed and approved by at least one other team member.
+- [ ] A rollback plan exists (redeploying previous contract IDs).
+- [ ] The `.env` file from the previous testnet deploy is backed up separately (not overwritten).
+
+### 1. Create a mainnet deployer identity
+
+```bash
+stellar keys generate deployer --network mainnet
+```
+
+### 2. Fund the deployer account
+
+Send real XLM to the deployer address:
+
+```bash
+stellar keys address deployer
+# Send XLM to the output address from a funded Stellar account or exchange
+```
+
+The account needs enough for:
+- Escrow contract deploy fee
+- Oracle contract deploy fee
+- Two initialization invocations
+- Minimum account balance (~1 XLM)
+
+10–20 XLM is a comfortable buffer.
+
+### 3. Run the deploy script
+
+```bash
+./scripts/deploy_mainnet.sh
+```
+
+The script is identical to the testnet version except:
+- Targets `mainnet` network and RPC endpoints.
+- Does **not** call Friendbot (no Friendbot exists for mainnet).
+- Prompts for confirmation before proceeding.
+- Updates all `STELLAR_NETWORK` and `VITE_STELLAR_NETWORK` fields in `.env` to `mainnet`.
+
+**Expected output:**
+```
+Deployer: GXYZ...
+Network:  mainnet (PUBLIC — real XLM will be spent)
+
+Continue with mainnet deployment? [y/N] y
+Building contracts...
+Deploying escrow contract...
+Escrow contract: CC789...
+Deploying oracle contract...
+Oracle contract: CC012...
+Initializing oracle contract...
+Initializing escrow contract...
+
+Mainnet deployment complete.
+  Escrow:  CC789...
+  Oracle:  CC012...
+Contract IDs written to .env
+```
+
+### 4. Post-deploy verification
+
+Run the same verification as testnet (step 3 above), but use mainnet RPC and passphrase:
+
+```bash
+MAINNET_RPC="https://soroban-mainnet.stellar.org"
+MAINNET_PASSPHRASE="Public Global Stellar Network ; September 2015"
+
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source deployer \
+  --network mainnet \
+  --rpc-url "$MAINNET_RPC" \
+  --network-passphrase "$MAINNET_PASSPHRASE" \
+  -- get_match \
+  --match_id 0
+
+stellar contract invoke \
+  --id "$CONTRACT_ORACLE" \
+  --source deployer \
+  --network mainnet \
+  --rpc-url "$MAINNET_RPC" \
+  --network-passphrase "$MAINNET_PASSPHRASE" \
+  -- has_result \
+  --match_id 0
+```
+
+Additionally:
+
+- [ ] Record contract IDs in a secure, durable location (e.g., a password manager, team wiki, or a GitHub release).
+- [ ] Verify the admin and oracle addresses stored on-chain are correct with `stellar contract inspect`.
+- [ ] Run a smoke test: create a test match, deposit stake, and cancel it to verify the full flow.
+- [ ] Update the frontend configuration with the new mainnet contract IDs and network.
+
+## Troubleshooting
+
+### `stellar: command not found`
+
+The Stellar CLI is not installed or not in `PATH`.
+
+**Fix:** Install from https://developers.stellar.org/docs/tools/developer-tools/cli/install-cli
+
+### `identity 'deployer' not found`
+
+The deployer keypair has not been created yet.
+
+**Fix:**
+```bash
+stellar keys generate deployer --network testnet
+```
+
+### `Account does not exist` or `insufficient funds`
+
+The deployer account has no XLM balance.
+
+**Fix (testnet):** The deploy script funds via Friendbot automatically. If it fails, run manually:
+```bash
+curl -sf "https://friendbot.stellar.org?addr=$(stellar keys address deployer)"
+```
+
+**Fix (mainnet):** Send real XLM to the deployer address from a funded account.
+
+### `wasm file not found after build`
+
+The WASM build failed or produced output in an unexpected location.
+
+**Fix:** Run the build separately to see errors:
+```bash
+cargo build --target wasm32-unknown-unknown --release
+```
+Common causes:
+- Missing `wasm32-unknown-unknown` target: `rustup target add wasm32-unknown-unknown`
+- Rust toolchain too old: `rustup update`
+- Compilation errors in contract code
+
+### `Invoke failed: Error::AlreadyInitialized`
+
+One of the contracts was already initialized. This happens if the deploy script was run twice without deploying new contracts.
+
+**Fix:** Deploy fresh contracts (the script deploys new instances each run). If you want to re-use existing contracts, skip initialization and just update `.env` with the existing IDs.
+
+### `Invoke failed: error decoding response: ...`
+
+The contract invocation succeeded but the response format was unexpected. This usually means the contract is live and responding — check that the function name and arguments match the contract interface.
+
+**Fix:** Verify you are using the correct function name and parameter types. See `docs/api-reference.md` for the full contract API.
+
+### Timeout during deploy or invoke
+
+Network congestion or RPC endpoint issues.
+
+**Fix:** Retry the command. If the problem persists, verify the RPC endpoint is healthy:
+```bash
+curl -s <rpc-url> | head -20
+```
+You can also increase timeouts with the `--timeout` flag on `stellar` commands.


### PR DESCRIPTION
Closes #902 
Closes #903 
Closes #904 
Closes #905 

Closes two documentation tasks:

1. **environments.toml documentation** — Added a field reference table to README.md documenting all environments.toml fields (network, network_passphrase, rpc_url, horizon_url) with type, description, example values, and required/optional designation.

2. **CHANGELOG.md** — Rewrote CHANGELOG.md following the Keep a Changelog format with Added, Fixed, Changed, and Security sections. Includes entries for all completed features, bug fixes with issue references, and security improvements. Tagged current state as v0.2.0.