### PR TITLE
docs: resolve issues #896 #897 #898 #899

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1,3 +1,49 @@
+//! # Escrow Contract
+//!
+//! Trustless chess-match escrow on Stellar Soroban. Players stake XLM or USDC before a game;
+//! the verified winner is paid out automatically the moment the oracle submits the result.
+//!
+//! ## State Machine
+//!
+//! Every match moves through the following states. Invalid transitions are rejected on-chain
+//! with [`Error::InvalidState`].
+//!
+//! ```text
+//! (none) ──create_match()──► Pending
+//!                                │
+//!                ┌───────────────┤
+//!                │               │
+//!         cancel_match()    deposit() × 2
+//!                │               │
+//!                ▼               ▼
+//!            Cancelled        Active
+//!                           (funds held)
+//!                                │
+//!                         submit_result()
+//!                          (oracle only)
+//!                                │
+//!                                ▼
+//!                           Completed
+//!                          (payout done)
+//! ```
+//!
+//! `Cancelled` and `Completed` are **terminal** — no further transitions are possible.
+//!
+//! ## Key Data Structures
+//!
+//! - [`Match`](types::Match) — full record of a single betting match stored in persistent storage.
+//! - [`MatchState`](types::MatchState) — lifecycle enum driving the state machine above.
+//! - [`Winner`](types::Winner) — payout outcome: `Player1`, `Player2`, or `Draw`.
+//! - [`Platform`](types::Platform) — chess platform the game is hosted on (`Lichess` / `ChessDotCom`).
+//! - [`DataKey`](types::DataKey) — all storage keys used by the contract.
+//! - [`Error`](errors::Error) — every error code the contract can return.
+//!
+//! ## Further Reading
+//!
+//! - Architecture & sequence diagrams: [`docs/architecture.md`](../../docs/architecture.md)
+//! - Full API reference with CLI examples: [`docs/api-reference.md`](../../docs/api-reference.md)
+//! - Emergency procedures: [`docs/runbook.md`](../../docs/runbook.md)
+
 #![no_std]
 
 mod errors;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -800,6 +800,264 @@ const MAX_GAME_ID_LEN: u32   = 64;      // Maximum game_id byte length
 
 ---
 
+## Soroban CLI Invocations
+
+All examples below assume the following environment variables are set:
+
+```bash
+export NETWORK=testnet
+export CONTRACT_ESCROW=<escrow-contract-id>
+export CONTRACT_ORACLE=<oracle-contract-id>
+export TOKEN_ADDRESS=<sep41-token-contract-id>
+export ADMIN_ADDRESS=<admin-stellar-address>
+export ORACLE_ADDRESS=<oracle-stellar-address>
+export PLAYER1_ADDRESS=<player1-stellar-address>
+export PLAYER2_ADDRESS=<player2-stellar-address>
+```
+
+### Escrow Contract CLI Examples
+
+#### initialize
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source admin-key \
+  --network "$NETWORK" \
+  -- initialize \
+  --oracle "$ORACLE_ADDRESS" \
+  --admin "$ADMIN_ADDRESS" \
+  --token "$TOKEN_ADDRESS"
+```
+
+#### pause
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source admin-key \
+  --network "$NETWORK" \
+  -- pause
+```
+
+#### unpause
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source admin-key \
+  --network "$NETWORK" \
+  -- unpause
+```
+
+#### update_oracle
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source admin-key \
+  --network "$NETWORK" \
+  -- update_oracle \
+  --new_oracle "$NEW_ORACLE_ADDRESS"
+```
+
+#### create_match
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source player1-key \
+  --network "$NETWORK" \
+  -- create_match \
+  --player1 "$PLAYER1_ADDRESS" \
+  --player2 "$PLAYER2_ADDRESS" \
+  --stake_amount 1000000000 \
+  --token "$TOKEN_ADDRESS" \
+  --game_id "lichess_abc123" \
+  --platform '{"Lichess":{}}'
+# Returns: u64 match_id
+```
+
+For Chess.com:
+
+```bash
+  --platform '{"ChessDotCom":{}}'
+```
+
+#### deposit
+
+```bash
+# Player 1 deposits
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source player1-key \
+  --network "$NETWORK" \
+  -- deposit \
+  --match_id 0 \
+  --player "$PLAYER1_ADDRESS"
+
+# Player 2 deposits (match transitions to Active after this)
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source player2-key \
+  --network "$NETWORK" \
+  -- deposit \
+  --match_id 0 \
+  --player "$PLAYER2_ADDRESS"
+```
+
+#### cancel_match
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source player2-key \
+  --network "$NETWORK" \
+  -- cancel_match \
+  --match_id 0 \
+  --caller "$PLAYER2_ADDRESS"
+```
+
+#### submit_result (escrow)
+
+```bash
+# Player 1 wins
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source oracle-key \
+  --network "$NETWORK" \
+  -- submit_result \
+  --match_id 0 \
+  --game_id "lichess_abc123" \
+  --winner '{"Player1":{}}' \
+  --caller "$ORACLE_ADDRESS"
+
+# Player 2 wins
+  --winner '{"Player2":{}}'
+
+# Draw
+  --winner '{"Draw":{}}'
+```
+
+#### emergency_drain
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source admin-key \
+  --network "$NETWORK" \
+  -- emergency_drain \
+  --to "$SAFE_COLD_WALLET_ADDRESS" \
+  --caller "$ADMIN_ADDRESS"
+```
+
+#### get_match
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source any-key \
+  --network "$NETWORK" \
+  -- get_match \
+  --match_id 0
+```
+
+#### is_funded
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source any-key \
+  --network "$NETWORK" \
+  -- is_funded \
+  --match_id 0
+# Returns: true | false
+```
+
+#### get_escrow_balance
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source any-key \
+  --network "$NETWORK" \
+  -- get_escrow_balance \
+  --match_id 0
+# Returns: i128 (0, stake_amount, or 2 * stake_amount)
+```
+
+---
+
+### Oracle Contract CLI Examples
+
+#### initialize (oracle)
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ORACLE" \
+  --source admin-key \
+  --network "$NETWORK" \
+  -- initialize \
+  --admin "$ORACLE_ADDRESS"
+```
+
+#### submit_result (oracle)
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ORACLE" \
+  --source oracle-key \
+  --network "$NETWORK" \
+  -- submit_result \
+  --match_id 0 \
+  --game_id "lichess_abc123" \
+  --result '{"Player1Wins":{}}'
+
+# Other result variants:
+  --result '{"Player2Wins":{}}'
+  --result '{"Draw":{}}'
+```
+
+#### get_result
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ORACLE" \
+  --source any-key \
+  --network "$NETWORK" \
+  -- get_result \
+  --match_id 0
+# Returns: ResultEntry { game_id, result }
+```
+
+#### has_result
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ORACLE" \
+  --source any-key \
+  --network "$NETWORK" \
+  -- has_result \
+  --match_id 0
+# Returns: true | false
+```
+
+#### transfer_admin (oracle)
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ORACLE" \
+  --source oracle-key \
+  --network "$NETWORK" \
+  -- transfer_admin \
+  --new_admin "$NEW_ORACLE_ADDRESS"
+```
+
+---
+
+> **Keeping this document in sync:** When adding or changing a public contract function,
+> update this file in the same PR. The PR template includes a checklist item for this.
+
 ## Usage Examples
 
 ### Complete Match Flow

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,6 +79,83 @@ All token transfers use the Stellar Asset Contract (SAC) interface via `soroban_
 
 All persistent entries are written with a TTL of `518_400` ledgers (~30 days at 5 s/ledger). The TTL is refreshed on every state-changing write to prevent expiry during an active match.
 
+## Sequence Diagrams
+
+### Happy Path — Player 1 Wins
+
+The diagram below shows the full flow from match creation through winner payout when Player 1
+wins the game.
+
+```mermaid
+sequenceDiagram
+    actor P1 as Player 1
+    actor P2 as Player 2
+    participant EC as Escrow Contract
+    participant OC as Oracle Contract
+    participant OOS as Off-chain Oracle Service
+    participant Chess as Lichess / Chess.com API
+
+    P1->>EC: create_match(player1, player2, stake, game_id, Lichess)
+    EC-->>P1: match_id
+
+    P1->>EC: deposit(match_id, player1)
+    EC-->>P1: ok (1 of 2 deposits received)
+
+    P2->>EC: deposit(match_id, player2)
+    EC-->>P2: ok — match transitions to Active
+    EC--)EC: emit ("match", "activated")
+
+    Note over P1,P2: Players play the chess game on Lichess
+
+    Chess-->>OOS: game result available (Player 1 wins)
+    OOS->>OC: submit_result(match_id, game_id, Player1Wins)
+    OC-->>OOS: ok
+    OC--)OC: emit ("oracle", "result")
+
+    OOS->>EC: submit_result(match_id, game_id, Player1, oracle_addr)
+    EC->>EC: verify game_id match & Active state
+    EC->>P1: transfer(stake × 2)
+    EC-->>OOS: ok — match transitions to Completed
+    EC--)EC: emit ("match", "completed")
+```
+
+### Draw Path — Stakes Refunded
+
+This diagram shows the flow when the game ends in a draw. Both players receive their original
+stake back.
+
+```mermaid
+sequenceDiagram
+    actor P1 as Player 1
+    actor P2 as Player 2
+    participant EC as Escrow Contract
+    participant OC as Oracle Contract
+    participant OOS as Off-chain Oracle Service
+    participant Chess as Lichess / Chess.com API
+
+    P1->>EC: create_match(player1, player2, stake, game_id, Lichess)
+    EC-->>P1: match_id
+
+    P1->>EC: deposit(match_id, player1)
+    EC-->>P1: ok
+
+    P2->>EC: deposit(match_id, player2)
+    EC-->>P2: ok — match transitions to Active
+
+    Note over P1,P2: Players play the chess game on Lichess
+
+    Chess-->>OOS: game result available (Draw)
+    OOS->>OC: submit_result(match_id, game_id, Draw)
+    OC-->>OOS: ok
+    OC--)OC: emit ("oracle", "result")
+
+    OOS->>EC: submit_result(match_id, game_id, Draw, oracle_addr)
+    EC->>P1: transfer(stake)
+    EC->>P2: transfer(stake)
+    EC-->>OOS: ok — match transitions to Completed
+    EC--)EC: emit ("match", "completed")
+```
+
 ## Events
 
 | Contract | Topics | Data |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,121 +1,370 @@
-# Emergency Drain Runbook
+# Operational Runbook — smile4money
 
-Procedure for using `emergency_drain` to recover funds from the escrow contract during a critical exploit.
+> **Audience:** On-call engineers and administrators with access to the admin private key.
+> **Scope:** Emergency response, oracle key rotation, and post-incident analysis.
 
-## When to use this
+---
 
-Use `emergency_drain` only when:
+## Table of Contents
 
-- An active exploit is draining or threatening to drain the escrow contract, **and**
-- There is no time to wait for match resolution via the oracle.
+1. [Emergency Contract Pause](#1-emergency-contract-pause)
+2. [Oracle Signing Key Rotation](#2-oracle-signing-key-rotation)
+3. [Emergency Fund Drain](#3-emergency-fund-drain)
+4. [Unpausing the Contract](#4-unpausing-the-contract)
+5. [Post-Incident Report Template](#5-post-incident-report-template)
+6. [Contact Escalation List](#6-contact-escalation-list)
 
-Do **not** use it for routine administration. The function transfers every token the contract holds to a single address in one transaction, bypassing all per-match accounting.
+---
 
-## Prerequisites
+## 1. Emergency Contract Pause
 
-- The **admin private key** for the deployed contract.
-- A **safe cold-wallet address** (`SAFE_ADDRESS`) controlled offline or by multi-sig, never the admin hot wallet.
-- The **Stellar CLI** (`stellar`) installed and configured for the target network.
-- The **contract address** (`CONTRACT_ADDRESS`) of the deployed escrow contract.
+**When to use:** Suspected exploit, incorrect payout, oracle compromise, or any situation where
+halting new activity is safer than continuing operations.
 
-## Step-by-step
+**Who can pause:** Only the `admin` address set during `initialize`.
 
-### 1. Confirm the exploit
+**Effect:** Blocks `create_match`, `deposit`, and `submit_result`. `cancel_match` remains
+available so players can always recover their funds.
 
-Before draining, verify the threat is real:
+### Steps
+
+#### 1.1 Confirm the admin identity
 
 ```bash
-stellar contract invoke \
-  --id $CONTRACT_ADDRESS \
-  --network $NETWORK \
-  -- get_match --match_id <id>
+# Verify your local key matches the on-chain admin
+stellar keys address admin-key
+# Compare output against the CONTRACT_ADMIN value in your .env
 ```
 
-Check unusual state transitions, repeated results submitted for the same match, or the contract balance dropping unexpectedly.
-
-### 2. Pause the contract
-
-Pausing blocks `create_match`, `deposit`, and `submit_result` immediately.
+#### 1.2 Pause the escrow contract
 
 ```bash
 stellar contract invoke \
-  --id $CONTRACT_ADDRESS \
-  --source $ADMIN_SECRET_KEY \
-  --network $NETWORK \
+  --id "$CONTRACT_ESCROW" \
+  --source admin-key \
+  --network testnet \
   -- pause
 ```
 
-Confirm the contract is paused before proceeding. Any subsequent call to `create_match` or `deposit` should return `Error::ContractPaused (9)`.
+For **mainnet**, replace `--network testnet` with `--network mainnet`.
 
-### 3. Drain to the safe address
+#### 1.3 Verify the pause is in effect
+
+```bash
+# This call should return an error: Error::ContractPaused (code 9)
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source any-key \
+  --network testnet \
+  -- create_match \
+  --player1 GDUMMY1 \
+  --player2 GDUMMY2 \
+  --stake_amount 1 \
+  --token GDUMMY3 \
+  --game_id test \
+  --platform '{"Lichess":{}}'
+# Expected output: error code 9 (ContractPaused)
+```
+
+Alternatively, query the `Paused` instance storage key using Stellar's RPC:
+
+```bash
+curl -s "https://soroban-testnet.stellar.org" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"getLedgerEntries",
+    "params":{"keys":["<PAUSED_LEDGER_KEY_XDR>"]}
+  }'
+```
+
+#### 1.4 Notify the team
+
+Post to the incident channel immediately:
+
+```
+[INCIDENT] Escrow contract PAUSED at ledger <N> by <admin-address>.
+Reason: <brief description>
+Next action: <investigation / drain / oracle rotation>
+```
+
+---
+
+## 2. Oracle Signing Key Rotation
+
+**When to use:** Oracle private key is compromised, exposed in logs, or as a scheduled rotation.
+
+**Who can rotate:** Only the `admin` address.
+
+### Steps
+
+#### 2.1 Generate a new oracle keypair
+
+```bash
+stellar keys generate new-oracle-key --network testnet
+stellar keys address new-oracle-key
+# Save the output address as NEW_ORACLE_ADDRESS
+```
+
+For mainnet, **generate the keypair offline** on an air-gapped machine and import the public
+address only:
+
+```bash
+# On air-gapped machine
+stellar keys generate new-oracle-key
+stellar keys address new-oracle-key   # copy this address
+
+# On connected machine — fund the new account
+stellar account fund --address <NEW_ORACLE_ADDRESS> --network testnet
+```
+
+#### 2.2 Fund the new oracle account (testnet)
+
+```bash
+stellar account fund --address "$NEW_ORACLE_ADDRESS" --network testnet
+```
+
+#### 2.3 Call `update_oracle` on the escrow contract
 
 ```bash
 stellar contract invoke \
-  --id $CONTRACT_ADDRESS \
-  --source $ADMIN_SECRET_KEY \
-  --network $NETWORK \
+  --id "$CONTRACT_ESCROW" \
+  --source admin-key \
+  --network testnet \
+  -- update_oracle \
+  --new_oracle "$NEW_ORACLE_ADDRESS"
+```
+
+#### 2.4 Call `transfer_admin` on the oracle contract
+
+The oracle **contract** also has its own admin (the off-chain service key). Rotate it too:
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ORACLE" \
+  --source old-oracle-key \
+  --network testnet \
+  -- transfer_admin \
+  --new_admin "$NEW_ORACLE_ADDRESS"
+```
+
+#### 2.5 Verify the new oracle is registered
+
+```bash
+# Submit a test result with the new key (use a safe test match_id on testnet)
+stellar contract invoke \
+  --id "$CONTRACT_ORACLE" \
+  --source new-oracle-key \
+  --network testnet \
+  -- submit_result \
+  --match_id 0 \
+  --game_id "rotation-verify-test" \
+  --result '{"Player1Wins":{}}'
+```
+
+Expected: success (or `AlreadySubmitted` if a result already exists — both confirm auth works).
+
+#### 2.6 Update the oracle service configuration
+
+```bash
+# In the oracle service deployment (e.g., systemd, Docker, or cloud secret store):
+# Replace ORACLE_SIGNING_KEY with the new key
+# Restart the oracle service and confirm it re-connects successfully
+systemctl restart smile4money-oracle   # or equivalent
+journalctl -u smile4money-oracle -f    # watch for errors
+```
+
+#### 2.7 Revoke and destroy the old key
+
+- Remove the old key from all `.env` files and secret stores.
+- If using a hardware wallet, revoke the signing slot.
+- Document the rotation in the incident log.
+
+---
+
+## 3. Emergency Fund Drain
+
+**When to use:** Active exploit with no time for match-by-match resolution. Transfers the
+entire contract token balance to a safe cold-wallet address.
+
+> ⚠️ **This is irreversible.** All in-progress matches will lose their escrowed funds.
+> Use only when the alternative is losing more funds to an exploit.
+
+### Prerequisites
+
+- Contract must be **paused** (see §1).
+- A **safe cold-wallet address** (`SAFE_ADDRESS`) that is NOT the admin hot wallet.
+
+### Steps
+
+#### 3.1 Confirm the contract is paused (see §1.3)
+
+#### 3.2 Execute the drain
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source admin-key \
+  --network testnet \
   -- emergency_drain \
-     --to $SAFE_ADDRESS \
-     --caller $ADMIN_ADDRESS
+  --to "$SAFE_ADDRESS" \
+  --caller "$ADMIN_ADDRESS"
 ```
 
-`emergency_drain` will:
-
-1. Verify `caller` is the registered admin.
-2. Verify the contract is paused (returns `Error::NotPaused (18)` otherwise).
-3. Query the contract's token balance.
-4. Transfer the full balance to `to`.
-5. Emit an `admin:drain` event recording `(amount, to, admin)`.
-
-If the balance is zero the call succeeds silently (no transfer is attempted).
-
-### 4. Verify the transfer
+#### 3.3 Confirm balance is zero
 
 ```bash
 stellar contract invoke \
-  --id $TOKEN_ADDRESS \
-  --network $NETWORK \
-  -- balance --id $SAFE_ADDRESS
+  --id "$CONTRACT_ESCROW" \
+  --source any-key \
+  --network testnet \
+  -- get_escrow_balance \
+  --match_id 0
+# Should return 0 for all match IDs
 ```
 
-The safe address should hold the drained amount. The contract balance should be zero.
-
-### 5. Record the incident
-
-Document:
-
-- UTC timestamp of `pause()` and `emergency_drain()`.
-- Transaction hashes for both calls.
-- Amount drained and destination address.
-- Root cause (if known at time of drain).
-
-Keep this in an incident log separate from the repository.
-
-### 6. Post-incident
-
-After the exploit is fully understood and patched:
-
-- Deploy a new contract version.
-- Redistribute funds from `SAFE_ADDRESS` to affected players based on the match state at time of pause.
-- Unpause or retire the old contract as appropriate.
+Check the contract's raw token balance:
 
 ```bash
-# Unpause (only if continuing to use the same contract)
 stellar contract invoke \
-  --id $CONTRACT_ADDRESS \
-  --source $ADMIN_SECRET_KEY \
-  --network $NETWORK \
+  --id "$TOKEN_ADDRESS" \
+  --source any-key \
+  --network testnet \
+  -- balance \
+  --id "$CONTRACT_ESCROW"
+# Expected: 0
+```
+
+#### 3.4 Record the drain transaction hash and notify all stakeholders
+
+---
+
+## 4. Unpausing the Contract
+
+Only unpause after the incident is fully resolved and the root cause has been addressed.
+
+### Checklist before unpausing
+
+- [ ] Root cause identified and fixed (contract upgrade or oracle key rotated)
+- [ ] All affected matches manually reconciled (refunds issued if needed)
+- [ ] At least one other team member has reviewed and signed off
+- [ ] Incident report drafted (see §5)
+
+### Command
+
+```bash
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source admin-key \
+  --network testnet \
   -- unpause
 ```
 
-## Error reference
+### Verify
 
-| Error | Code | Meaning |
-|-------|------|---------|
-| `NotPaused` | 18 | `emergency_drain` called without pausing first |
-| `Unauthorized` | 4 | `caller` is not the registered admin |
+```bash
+# Should succeed and return a match_id
+stellar contract invoke \
+  --id "$CONTRACT_ESCROW" \
+  --source player1-key \
+  --network testnet \
+  -- create_match \
+  --player1 "$PLAYER1_ADDRESS" \
+  --player2 "$PLAYER2_ADDRESS" \
+  --stake_amount 10000000 \
+  --token "$TOKEN_ADDRESS" \
+  --game_id "post-incident-verify" \
+  --platform '{"Lichess":{}}'
+```
 
-## Future enhancements
+---
 
-- **Time-lock**: enforce a minimum delay (e.g., 24 h) between `pause()` and `emergency_drain()` so players can challenge an illegitimate drain before it executes.
-- **Multi-sig**: require M-of-N admin key signatures so no single compromised key can drain the contract unilaterally.
+## 5. Post-Incident Report Template
+
+Copy this template and fill it in for every incident, regardless of severity.
+
+---
+
+### Incident Report — [YYYY-MM-DD] [Brief Title]
+
+**Severity:** Critical / High / Medium / Low
+**Status:** Open / Resolved
+**Report Author:** [Name / GitHub handle]
+**Reviewed by:** [Name / GitHub handle]
+
+#### Timeline
+
+| Time (UTC) | Event |
+|------------|-------|
+| HH:MM | Incident detected (how: alert / user report / monitoring) |
+| HH:MM | On-call engineer paged |
+| HH:MM | Contract paused at ledger N (tx hash: `...`) |
+| HH:MM | Root cause identified |
+| HH:MM | Fix deployed / oracle rotated |
+| HH:MM | Contract unpaused at ledger N (tx hash: `...`) |
+| HH:MM | Incident resolved |
+
+#### Impact
+
+- **Users affected:** [number / description]
+- **Funds at risk:** [amount in XLM/USDC]
+- **Funds lost:** [amount, or "none"]
+- **Matches disrupted:** [match IDs]
+- **Duration of outage:** [HH:MM]
+
+#### Root Cause
+
+[One paragraph describing what went wrong, why it happened, and what allowed it to occur.]
+
+#### What Went Well
+
+- [Item 1]
+- [Item 2]
+
+#### What Went Poorly
+
+- [Item 1]
+- [Item 2]
+
+#### Remediation
+
+| Action | Owner | Due Date | Status |
+|--------|-------|----------|--------|
+| [Fix description] | [Name] | YYYY-MM-DD | Open |
+| [Monitoring improvement] | [Name] | YYYY-MM-DD | Open |
+| [Runbook update] | [Name] | YYYY-MM-DD | Open |
+
+#### Sign-off
+
+- [ ] Incident lead reviewed
+- [ ] Second team member reviewed
+- [ ] Remediation items tracked in GitHub Issues
+
+---
+
+## 6. Contact Escalation List
+
+> Replace placeholder entries with real contact information before deploying to mainnet.
+
+| Role | Contact | How to reach |
+|------|---------|--------------|
+| On-call engineer (primary) | [Name] | PagerDuty / Signal |
+| On-call engineer (backup) | [Name] | PagerDuty / Signal |
+| Contract admin keyholder | [Name] | End-to-end encrypted message only |
+| Oracle service owner | [Name] | Slack `#oracle-ops` |
+| Stellar network status | SDF | https://status.stellar.org |
+| Lichess API status | Lichess | https://lichess.org/status |
+| Chess.com API status | Chess.com | https://www.chess.com/news |
+
+### Escalation path
+
+1. On-call primary — immediate (0–15 min)
+2. On-call backup — if primary unreachable (15–30 min)
+3. Contract admin keyholder — required for pause/drain/oracle rotation
+4. All team leads — severity Critical only
+
+---
+
+*This runbook is a living document. Update it whenever a procedure changes or a gap is discovered
+during an incident. The reviewing engineer is responsible for merging updates.*


### PR DESCRIPTION
Closes #899
closes #898 
closes #897 
closes #896 

---

## Summary

Closes four documentation issues simultaneously:

---

### Issue #896 — Write docs/runbook.md: emergency procedures and operational playbook

**File:** docs/runbook.md (rewritten from a partial emergency-drain stub to a full operational runbook)

**What was done:**
- Added a complete emergency contract pause procedure (§1) with exact `stellar contract invoke` CLI commands, a verification step (calling a blocked function to confirm error code 9 is returned), and a team notification template.
- Added an oracle signing key rotation procedure (§2) covering: generating a new keypair with `stellar keys generate`, funding the account on testnet, calling `update_oracle` on the escrow contract, calling `transfer_admin` on the oracle contract, verifying the new key by submitting a test result, updating the off-chain oracle service, and revoking the old key.
- Added an emergency fund drain procedure (§3) referencing the `emergency_drain` function, with a pre-requisite checklist (contract must be paused), the exact CLI invocation, and a balance verification step.
- Added an unpause procedure (§4) with a sign-off checklist to ensure root cause is fixed before re-enabling the contract.
- Added a post-incident report template (§5) with structured sections: timeline table, impact metrics, root cause paragraph, what went well / poorly, and a remediation action table.
- Added a contact escalation list (§6) with roles, placeholder contacts, and a 4-step escalation path.

---

### Issue #897 — Add sequence diagrams to docs/architecture.md

**File:** docs/architecture.md (two Mermaid sequenceDiagram blocks added)

**What was done:**
- Added a new "Sequence Diagrams" section inserted immediately before the existing "Events" table, with an explanatory caption for each diagram.
- Diagram 1 (Happy Path — Player 1 Wins): shows all actors (Player 1, Player 2, Escrow Contract, Oracle Contract, Off-chain Oracle Service, Lichess/Chess.com API) stepping through create_match → deposit × 2 → match activation → game played → oracle fetches result → oracle submits to OC → oracle triggers payout on EC → Player 1 receives stake × 2. Includes emitted events as self-messages on the contracts.
- Diagram 2 (Draw Path): identical actor set, shows the same flow but the oracle submits Draw and both players each receive their original stake_amount back.
- Both diagrams use standard Mermaid sequenceDiagram syntax and render correctly on GitHub.

---

### Issue #898 — Write comprehensive docs/api-reference.md

**File:** docs/api-reference.md (Soroban CLI invocations section added)

**What was done:**
- The file already contained complete function signatures, parameter descriptions, return types, errors, and SDK usage examples. The gap was the absence of CLI invocations.
- Added a new "Soroban CLI Invocations" section with a preamble defining the expected environment variables (NETWORK, CONTRACT_ESCROW, CONTRACT_ORACLE, TOKEN_ADDRESS, etc.).
- Provided `stellar contract invoke` commands for every public escrow function: initialize, pause, unpause, update_oracle, create_match (with both Platform variants), deposit (both players), cancel_match, submit_result (all three Winner variants), emergency_drain, get_match, is_funded, get_escrow_balance.
- Provided `stellar contract invoke` commands for every public oracle function: initialize, submit_result (all three MatchResult variants), get_result, has_result, transfer_admin.
- Added a maintenance note reminding contributors to update this file in the same PR as any contract change.

---

### Issue #899 — Add module-level doc comments to contracts/escrow/src/lib.rs

**File:** contracts/escrow/src/lib.rs (//! block added at the top)

**What was done:**
- Added a //! module-level doc comment block above the existing #![no_std] attribute.
- The block includes: contract purpose (trustless chess-match escrow on Stellar Soroban), a full ASCII state machine diagram matching the README, a "Key Data Structures" section with inline links to Match, MatchState, Winner, Platform, DataKey, and Error, and a "Further Reading" section pointing to docs/architecture.md, docs/api-reference.md, and docs/runbook.md.
- All existing /// doc comments on public functions are preserved unchanged.