### PR TITLE
feat(oracle): add delete_result admin function to correct mis-submitt…

### DIFF
--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -87,6 +87,33 @@ impl OracleContract {
         env.storage().persistent().has(&DataKey::Result(match_id))
     }
 
+    /// Admin deletes a mis-submitted result before the escrow contract processes it.
+    pub fn delete_result(env: Env, match_id: u64, caller: Address) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+
+        if caller != admin {
+            return Err(Error::Unauthorized);
+        }
+        caller.require_auth();
+
+        if !env.storage().persistent().has(&DataKey::Result(match_id)) {
+            return Err(Error::ResultNotFound);
+        }
+
+        env.storage().persistent().remove(&DataKey::Result(match_id));
+
+        env.events().publish(
+            (Symbol::new(&env, "oracle"), symbol_short!("res_del")),
+            (match_id, caller),
+        );
+
+        Ok(())
+    }
+
     /// Transfer admin rights to a new address. Requires current admin auth.
     pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), Error> {
         let admin: Address = env
@@ -267,6 +294,77 @@ mod tests {
             soroban_sdk::symbol_short!("adm_xfer").into_val(&env),
         ];
         assert!(events.iter().any(|(_, t, _)| t == topics));
+    }
+
+    #[test]
+    fn test_delete_result_authorized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(OracleContract, ());
+        let client = OracleContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        client.submit_result(&42u64, &String::from_str(&env, "game42"), &MatchResult::Draw);
+        assert!(client.has_result(&42u64));
+
+        client.delete_result(&42u64, &admin);
+
+        // Capture events immediately — env.events().all() returns events from
+        // the most recent invocation, so this must come before the next client call.
+        let events = env.events().all();
+        let topics = vec![
+            &env,
+            Symbol::new(&env, "oracle").into_val(&env),
+            soroban_sdk::symbol_short!("res_del").into_val(&env),
+        ];
+        assert!(events.iter().any(|(_, t, _)| t == topics));
+
+        assert!(!client.has_result(&42u64));
+    }
+
+    #[test]
+    fn test_delete_result_unauthorized() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let non_admin = Address::generate(&env);
+        let contract_id = env.register(OracleContract, ());
+        let client = OracleContractClient::new(&env, &contract_id);
+        env.mock_all_auths();
+        client.initialize(&admin);
+        client.submit_result(&10u64, &String::from_str(&env, "game10"), &MatchResult::Player1Wins);
+
+        use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
+        env.mock_auths(&[MockAuth {
+            address: &non_admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "delete_result",
+                args: (10u64, non_admin.clone()).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+
+        assert_eq!(
+            client.try_delete_result(&10u64, &non_admin),
+            Err(Ok(Error::Unauthorized))
+        );
+        assert!(client.has_result(&10u64));
+    }
+
+    #[test]
+    fn test_delete_result_not_found() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(OracleContract, ());
+        let client = OracleContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        assert_eq!(
+            client.try_delete_result(&999u64, &admin),
+            Err(Ok(Error::ResultNotFound))
+        );
     }
 
     #[test]

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -235,6 +235,36 @@ mod tests {
     }
 
     #[test]
+    fn test_submit_result_by_non_admin_returns_unauthorized() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let non_admin = Address::generate(&env);
+        let contract_id = env.register(OracleContract, ());
+        let client = OracleContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
+        env.mock_auths(&[MockAuth {
+            address: &non_admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "submit_result",
+                args: (1u64, String::from_str(&env, "game1"), MatchResult::Player1Wins)
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+
+        assert!(
+            client
+                .try_submit_result(&1u64, &String::from_str(&env, "game1"), &MatchResult::Player1Wins)
+                .is_err(),
+            "non-admin must not be able to submit results"
+        );
+        assert!(!client.has_result(&1u64), "result must not be stored after rejected submission");
+    }
+
+    #[test]
     fn test_double_initialize_fails() {
         let env = Env::default();
         env.mock_all_auths();


### PR DESCRIPTION
…ed results

Implements fn delete_result(env, match_id, caller) that verifies the caller is admin via caller.require_auth(), returns Error::ResultNotFound if no entry exists, removes the stored ResultEntry, and emits an oracle:res_del event.

Adds unit tests for authorized deletion, unauthorized rejection, and not-found path. Fixes test setup bugs where a fresh address was used instead of the actual stored admin, and orders event capture before subsequent client calls to match Soroban testutils event-buffer semantics.


## Description

<!-- Provide a clear and concise description of the changes in this PR. What
     problem does it solve? What is the expected behaviour after merge? -->

## Type of Change

<!-- Check the category that best describes this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## Testing

<!-- Describe the testing you performed to verify your changes. Include steps
     to reproduce, test commands, and any relevant output. -->

- [ ] Tests added or updated
- [ ] Manual testing performed

## Contract Changes

<!-- If this PR changes smart contracts (contracts/), complete this section. -->

- [ ] ABI breaking? (requires re-deployment of existing contracts)
- [ ] Storage migration needed?
- [ ] ABI reviewed for breaking changes

## Security

<!-- Highlight any security-relevant considerations. -->

- [ ] No secrets committed
- [ ] Security implications considered and documented

## Documentation

- [ ] Relevant docs updated (docs/ folder, README, etc.)
- [ ] 

- [ ] 
Closes #826
