### PR TITLE
test(oracle): add submit_result_by_non_admin_returns_unauthorized test

### DIFF
--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -208,6 +208,36 @@ mod tests {
     }
 
     #[test]
+    fn test_submit_result_by_non_admin_returns_unauthorized() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let non_admin = Address::generate(&env);
+        let contract_id = env.register(OracleContract, ());
+        let client = OracleContractClient::new(&env, &contract_id);
+        client.initialize(&admin);
+
+        use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
+        env.mock_auths(&[MockAuth {
+            address: &non_admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "submit_result",
+                args: (1u64, String::from_str(&env, "game1"), MatchResult::Player1Wins)
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+
+        assert!(
+            client
+                .try_submit_result(&1u64, &String::from_str(&env, "game1"), &MatchResult::Player1Wins)
+                .is_err(),
+            "non-admin must not be able to submit results"
+        );
+        assert!(!client.has_result(&1u64), "result must not be stored after rejected submission");
+    }
+
+    #[test]
     fn test_double_initialize_fails() {
         let env = Env::default();
         env.mock_all_auths();


### PR DESCRIPTION
Verifies that submit_result rejects callers who are not the registered admin. Mocks only the non-admin's authorization so that admin.require_auth() inside the contract fails, and asserts both that the call is rejected and that no result is written to storage.

Closes #827

## Description

<!-- Provide a clear and concise description of the changes in this PR. What
     problem does it solve? What is the expected behaviour after merge? -->

## Type of Change

<!-- Check the category that best describes this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## Testing

<!-- Describe the testing you performed to verify your changes. Include steps
     to reproduce, test commands, and any relevant output. -->

- [ ] Tests added or updated
- [ ] Manual testing performed

## Contract Changes

<!-- If this PR changes smart contracts (contracts/), complete this section. -->

- [ ] ABI breaking? (requires re-deployment of existing contracts)
- [ ] Storage migration needed?
- [ ] ABI reviewed for breaking changes

## Security

<!-- Highlight any security-relevant considerations. -->

- [ ] No secrets committed
- [ ] Security implications considered and documented

## Documentation

- [ ] Relevant docs updated (docs/ folder, README, etc.)
