### PR TITLE
ci: resolve issues #892 #893 #894 #895 — dependabot, branch protectio…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,58 @@
+version: 2
+
+updates:
+  # ── Issue #892: Cargo (Rust contracts) ───────────────────────────────────
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "obajecollinsmicheal-cmd"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # ── Issue #892: npm (frontend) ────────────────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/apps/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "obajecollinsmicheal-cmd"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # ── npm (backend) ─────────────────────────────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/apps/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "obajecollinsmicheal-cmd"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # ── GitHub Actions ────────────────────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "obajecollinsmicheal-cmd"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test
+  # ── Issue #894: Split into parallel escrow-tests and oracle-tests jobs ────
+  escrow-tests:
+    name: Escrow Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -37,11 +38,78 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 
-      - name: Run tests
-        run: cargo test --lib --verbose
+      - name: Run escrow tests
+        run: cargo test -p smile4money-escrow --lib --verbose
 
-      - name: Run doc tests
-        run: cargo test --doc --verbose
+      - name: Run escrow doc tests
+        run: cargo test -p smile4money-escrow --doc --verbose
+
+  oracle-tests:
+    name: Oracle Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+        with:
+          toolchain: 1.88.0
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Run oracle tests
+        run: cargo test -p smile4money-oracle --lib --verbose
+
+      - name: Run oracle doc tests
+        run: cargo test -p smile4money-oracle --doc --verbose
+
+  # ── Issue #895: cargo-tarpaulin coverage report with 80% threshold ────────
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+        with:
+          toolchain: 1.88.0
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin --locked
+
+      - name: Run coverage (enforce 80% threshold)
+        run: cargo tarpaulin --out Xml --out Html --fail-under 80 --verbose
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-${{ github.sha }}
+          path: |
+            cobertura.xml
+            tarpaulin-report.html
+          retention-days: 30
 
   clippy:
     name: Clippy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,43 @@ git ls-remote https://github.com/<owner>/<repo>.git refs/tags/<tag>
 
 ---
 
+## Branch Protection Rules
+
+The `master` branch is protected. The following rules are enforced for all pull requests:
+
+### Required Status Checks
+
+All of the jobs below must pass before a PR can be merged:
+
+| Check | Job name in CI |
+|-------|---------------|
+| Escrow unit & doc tests | `Escrow Tests` |
+| Oracle unit & doc tests | `Oracle Tests` |
+| Code coverage ≥ 80 % | `Coverage` |
+| Clippy (zero warnings) | `Clippy` |
+| Rust formatting | `Format` |
+| Prettier (frontend) | `Prettier` |
+| WASM build | `Build` |
+| environments.toml valid | `Validate environments.toml` |
+| Frontend type-check / lint / tests | `Frontend` |
+
+### Required Reviewers
+
+At least **1 approving review** from a repository maintainer is required before merge.
+
+### Merge Policy
+
+- Only **squash merges** are allowed — this keeps the commit history linear and readable.
+- Direct pushes to `master` are **blocked** for all contributors, including maintainers.
+- Branches must be **up to date** with `master` before merging.
+
+### Setting Up Branch Protection on a Fork
+
+If you are working on a personal fork, you can replicate these rules by following the
+[GitHub branch protection documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches).
+
+---
+
 ## Reporting Issues
 
 Open a GitHub issue with:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -86,6 +86,42 @@ docs: add contributing guide
 4. Ensure `cargo test` and `cargo clippy -- -D warnings` pass — CI will check both.
 5. Add a brief description of what changed and how it was tested.
 
+## Branch Protection Rules
+
+The `master` branch is protected. The following rules apply to all pull requests:
+
+### Required Status Checks
+
+Every PR must pass these CI jobs before it can be merged:
+
+| Check | CI job |
+|-------|--------|
+| Escrow unit & doc tests | `Escrow Tests` |
+| Oracle unit & doc tests | `Oracle Tests` |
+| Code coverage ≥ 80 % | `Coverage` |
+| Clippy (zero warnings) | `Clippy` |
+| Rust formatting | `Format` |
+| Prettier (frontend) | `Prettier` |
+| WASM build | `Build` |
+| environments.toml validation | `Validate environments.toml` |
+| Frontend type-check / lint / tests | `Frontend` |
+
+### Required Reviewers
+
+At least **1 approving review** from a maintainer is required.
+
+### Merge Policy
+
+- **Squash merge only** — keeps history linear.
+- **No direct pushes** to `master` — always open a PR.
+- Branches must be **up to date** with `master` before the merge button is enabled.
+
+### Setting Up Protections on a Fork
+
+Refer to the [GitHub branch protection documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) to mirror these rules on your fork.
+
+---
+
 ## Reporting Issues
 
 Open a GitHub issue with:


### PR DESCRIPTION
…n docs, parallel tests, tarpaulin coverage

Closes #892
Closes #893
Closes #894
Closes #895

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Issue #892 — Add dependabot.yml for Cargo and npm dependency updates ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Created .github/dependabot.yml from scratch.

Configured four update targets, all scheduled weekly on Mondays:
  - cargo  (root /):               covers contracts/escrow and contracts/oracle
    via the workspace Cargo.toml.
  - npm    (/apps/frontend):       covers the React/Vite frontend.
  - npm    (/apps/backend):        covers the Node.js backend.
  - github-actions (/):            keeps CI action SHAs up to date.

Every ecosystem entry sets:
  - labels: [dependencies]   so PRs are auto-labelled and easy to filter.
  - reviewers: [obajecollinsmicheal-cmd]  so the maintainer is auto-requested.
  - commit-message prefix: chore  to stay consistent with Conventional Commits.

Why: previously no automated dependency scanning existed, meaning known CVEs in Cargo or npm packages could sit unnoticed until a manual audit.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Issue #893 — Document branch protection rules in CONTRIBUTING.md ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Added a new 'Branch Protection Rules' section to both:
  - CONTRIBUTING.md  (root, primary contributor entry point)
  - docs/contributing.md  (docs mirror)

The section documents:
  - Every required CI status check mapped to its job name in ci.yml, including the two new parallel test jobs and the new coverage job.
  - Required reviewer count (1 maintainer approval).
  - Squash-merge only policy and the no-direct-push-to-master rule.
  - A link to the GitHub documentation for setting up equivalent protections on personal forks.

Why: new contributors had no way to know what was required to land a PR without reading CI failures after the fact.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Issue #894 — Split CI test job into parallel escrow-tests and oracle-tests ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Removed the single monolithic 'test' job from ci.yml and replaced it with two independent jobs that run in parallel on every push / PR:

  escrow-tests:
    cargo test -p smile4money-escrow --lib --verbose
    cargo test -p smile4money-escrow --doc --verbose

  oracle-tests:
    cargo test -p smile4money-oracle --lib --verbose
    cargo test -p smile4money-oracle --doc --verbose

Both jobs:
  - Use the same Rust toolchain pin (1.88.0) and wasm32 target as before.
  - Share the ~/.cargo/registry + ~/.cargo/git + target cache keyed on Cargo.lock, so redundant downloads are avoided.
  - Run entirely independently — an escrow failure does not block oracle results and vice versa, giving faster, clearer signal.

Package names (smile4money-escrow, smile4money-oracle) were verified against contracts/escrow/Cargo.toml and contracts/oracle/Cargo.toml.

Why: the serialised single test job caused unnecessary wait time as the suite grows. Parallel jobs cut wall-clock CI time roughly in half for independent contract test suites.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Issue #895 — Add cargo-tarpaulin coverage report and enforce 80% threshold ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Added a new 'coverage' job to ci.yml:

  1. Installs cargo-tarpaulin with --locked to pin the resolver.
  2. Runs: cargo tarpaulin --out Xml --out Html --fail-under 80 --verbose - Xml  → cobertura.xml  (machine-readable, compatible with Codecov / Coveralls / GitHub coverage annotations) - Html → tarpaulin-report.html  (human-readable diff browsing) - --fail-under 80  makes the job exit non-zero if line coverage drops below 80%, blocking the PR.
  3. Uploads both artefacts under coverage-<sha> with 30-day retention using if: always() so the report is available even on a threshold failure (essential for diagnosing which lines are uncovered).

The job reuses the same Rust toolchain and cargo cache setup as the other Rust jobs.

Why: without coverage measurement, deleted tests or new uncovered code paths were invisible. The 80% threshold and artefact upload give both a hard gate and a browsable report for every PR.

## Description

<!-- Provide a clear and concise description of the changes in this PR. What
     problem does it solve? What is the expected behaviour after merge? -->

## Type of Change

<!-- Check the category that best describes this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## Testing

<!-- Describe the testing you performed to verify your changes. Include steps
     to reproduce, test commands, and any relevant output. -->

- [ ] Tests added or updated
- [ ] Manual testing performed

## Contract Changes

<!-- If this PR changes smart contracts (contracts/), complete this section. -->

- [ ] ABI breaking? (requires re-deployment of existing contracts)
- [ ] Storage migration needed?
- [ ] ABI reviewed for breaking changes

## Security

<!-- Highlight any security-relevant considerations. -->

- [ ] No secrets committed
- [ ] Security implications considered and documented

## Documentation

- [ ] Relevant docs updated (docs/ folder, README, etc.)
