### PR TITLE
Add contract registry auth, deregistration, pause, and event cap support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "contracts/escrow",
     "contracts/oracle",
+    "contracts/contract-registry",
 ]
 resolver = "2"
 

--- a/contracts/contract-registry/Cargo.toml
+++ b/contracts/contract-registry/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "contract-registry"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/contract-registry/src/lib.rs
+++ b/contracts/contract-registry/src/lib.rs
@@ -1,0 +1,167 @@
+#![no_std]
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, Map, Symbol, Vec};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum Error {
+    Unauthorized = 1,
+    ContractPaused = 2,
+    MaxEventsReached = 3,
+    ContractNotFound = 4,
+    AlreadyRegistered = 5,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin = 0,
+    Paused = 1,
+    MaxEvents = 2,
+    Registrations = 3,
+    Events = 4,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct ContractRecord {
+    pub registrant: Address,
+    pub contract_id: Symbol,
+    pub active: bool,
+}
+
+#[contract]
+pub struct ContractRegistry;
+
+#[contractimpl]
+impl ContractRegistry {
+    pub fn initialize(env: Env, admin: Address, max_events: u32) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::Unauthorized);
+        }
+
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage().instance().set(&DataKey::MaxEvents, &max_events);
+        env.storage()
+            .instance()
+            .set(&DataKey::Registrations, &Map::<Symbol, ContractRecord>::new(&env));
+        env.storage().instance().set(&DataKey::Events, &Vec::<Symbol>::new(&env));
+
+        Ok(())
+    }
+
+    pub fn pause(env: Env, caller: Address) -> Result<(), Error> {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::Unauthorized)?;
+        if admin != caller {
+            return Err(Error::Unauthorized);
+        }
+        caller.require_auth();
+        env.storage().instance().set(&DataKey::Paused, &true);
+        Ok(())
+    }
+
+    pub fn unpause(env: Env, caller: Address) -> Result<(), Error> {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::Unauthorized)?;
+        if admin != caller {
+            return Err(Error::Unauthorized);
+        }
+        caller.require_auth();
+        env.storage().instance().set(&DataKey::Paused, &false);
+        Ok(())
+    }
+
+    pub fn register_contract(env: Env, caller: Address, contract_id: Symbol) -> Result<(), Error> {
+        Self::ensure_not_paused(&env)?;
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::Unauthorized)?;
+        if admin != caller {
+            return Err(Error::Unauthorized);
+        }
+        caller.require_auth();
+
+        let mut registrations: Map<Symbol, ContractRecord> = env.storage().instance().get(&DataKey::Registrations).unwrap();
+        if registrations.contains_key(contract_id.clone()) {
+            return Err(Error::AlreadyRegistered);
+        }
+
+        registrations.set(
+            contract_id.clone(),
+            ContractRecord {
+                registrant: caller.clone(),
+                contract_id: contract_id.clone(),
+                active: true,
+            },
+        );
+        env.storage().instance().set(&DataKey::Registrations, &registrations);
+        Ok(())
+    }
+
+    pub fn update_contract(env: Env, caller: Address, contract_id: Symbol) -> Result<(), Error> {
+        Self::ensure_not_paused(&env)?;
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::Unauthorized)?;
+        if admin != caller {
+            return Err(Error::Unauthorized);
+        }
+        caller.require_auth();
+
+        let registrations: Map<Symbol, ContractRecord> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Registrations)
+            .unwrap_or_else(|| Map::new(&env));
+        if !registrations.contains_key(contract_id.clone()) {
+            return Err(Error::ContractNotFound);
+        }
+        Ok(())
+    }
+
+    pub fn deregister_contract(env: Env, caller: Address, contract_id: Symbol) -> Result<(), Error> {
+        Self::ensure_not_paused(&env)?;
+        let mut registrations: Map<Symbol, ContractRecord> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Registrations)
+            .unwrap_or_else(|| Map::new(&env));
+        let record = registrations.get(contract_id.clone()).ok_or(Error::ContractNotFound)?;
+        let is_registrant = record.registrant == caller;
+        if !is_registrant {
+            let admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::Unauthorized)?;
+            if admin != caller {
+                return Err(Error::Unauthorized);
+            }
+        }
+        caller.require_auth();
+        registrations.remove(contract_id.clone());
+        env.storage().instance().set(&DataKey::Registrations, &registrations);
+        Ok(())
+    }
+
+    pub fn submit_event(env: Env, caller: Address, event_name: Symbol) -> Result<(), Error> {
+        Self::ensure_not_paused(&env)?;
+        caller.require_auth();
+        let max_events: u32 = env.storage().instance().get(&DataKey::MaxEvents).unwrap_or(0);
+        let mut events: Vec<Symbol> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Events)
+            .unwrap_or_else(|| Vec::new(&env));
+        if events.len() >= max_events {
+            return Err(Error::MaxEventsReached);
+        }
+        events.push_back(event_name);
+        env.storage().instance().set(&DataKey::Events, &events);
+        Ok(())
+    }
+
+    fn ensure_not_paused(env: &Env) -> Result<(), Error> {
+        let paused: bool = env.storage().instance().get(&DataKey::Paused).unwrap_or(false);
+        if paused {
+            return Err(Error::ContractPaused);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/contract-registry/src/test.rs
+++ b/contracts/contract-registry/src/test.rs
@@ -1,0 +1,82 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Env, Symbol};
+
+fn setup(env: &Env) -> (Address, Address, Address) {
+    let admin = Address::generate(env);
+    let caller = Address::generate(env);
+    let contract_id = env.register_contract(None, ContractRegistry);
+    let client = ContractRegistryClient::new(env, &contract_id);
+    client.initialize(&admin, &3);
+    (admin, caller, contract_id)
+}
+
+#[test]
+fn test_register_contract_requires_admin_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, caller, contract_id) = setup(&env);
+    let client = ContractRegistryClient::new(&env, &contract_id);
+
+    assert!(matches!(
+        client.try_register_contract(&caller, &Symbol::new(&env, "demo")),
+        Err(Ok(Error::Unauthorized))
+    ));
+}
+
+#[test]
+fn test_update_contract_requires_admin_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, caller, contract_id) = setup(&env);
+    let client = ContractRegistryClient::new(&env, &contract_id);
+
+    assert!(matches!(
+        client.try_update_contract(&caller, &Symbol::new(&env, "demo")),
+        Err(Ok(Error::Unauthorized))
+    ));
+}
+
+#[test]
+fn test_deregister_contract_allows_admin_or_registrant() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, _caller, contract_id) = setup(&env);
+    let client = ContractRegistryClient::new(&env, &contract_id);
+    let contract_symbol = Symbol::new(&env, "demo");
+
+    client.register_contract(&admin, &contract_symbol);
+    client.deregister_contract(&admin, &contract_symbol);
+}
+
+#[test]
+fn test_submit_event_respects_max_events_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, _, contract_id) = setup(&env);
+    let client = ContractRegistryClient::new(&env, &contract_id);
+
+    client.submit_event(&admin, &Symbol::new(&env, "one"));
+    client.submit_event(&admin, &Symbol::new(&env, "two"));
+    client.submit_event(&admin, &Symbol::new(&env, "three"));
+    assert!(matches!(
+        client.try_submit_event(&admin, &Symbol::new(&env, "four")),
+        Err(Ok(Error::MaxEventsReached))
+    ));
+}
+
+#[test]
+fn test_pause_and_unpause_admin_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, _, contract_id) = setup(&env);
+    let client = ContractRegistryClient::new(&env, &contract_id);
+
+    client.pause(&admin);
+    assert!(matches!(
+        client.try_submit_event(&admin, &Symbol::new(&env, "blocked")),
+        Err(Ok(Error::ContractPaused))
+    ));
+    client.unpause(&admin);
+}


### PR DESCRIPTION
## Summary
- add admin-only auth guard coverage for register/update paths
- implement contract deregistration for admin or registrant
- add configurable event cap enforcement for submit_event
- add admin pause/unpause support

Closes #851
Closes #846
Closes #843
Closes #841