### PR TITLE
test(escrow): add test for get_escrow_balance after single deposit (#…

### DIFF
--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -840,6 +840,24 @@ fn test_is_funded_false_after_one_deposit() {
     assert!(client.is_funded(&id));
 }
 
+// Issue #818: get_escrow_balance returns stake_amount after only one deposit
+#[test]
+fn test_escrow_balance_after_single_deposit() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "single_deposit"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    assert_eq!(client.get_escrow_balance(&id), 100);
+}
+
 #[test]
 fn test_escrow_balance_stages() {
     let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();


### PR DESCRIPTION
…818)

Assert that get_escrow_balance returns stake_amount when only player1 has deposited, covering the partial funding state.

## Description

<!-- Provide a clear and concise description of the changes in this PR. What
     problem does it solve? What is the expected behaviour after merge? -->

## Type of Change

<!-- Check the category that best describes this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## Testing

<!-- Describe the testing you performed to verify your changes. Include steps
     to reproduce, test commands, and any relevant output. -->

- [ ] Tests added or updated
- [ ] Manual testing performed

## Contract Changes

<!-- If this PR changes smart contracts (contracts/), complete this section. -->

- [ ] ABI breaking? (requires re-deployment of existing contracts)
- [ ] Storage migration needed?
- [ ] ABI reviewed for breaking changes

## Security

<!-- Highlight any security-relevant considerations. -->

- [ ] No secrets committed
- [ ] Security implications considered and documented

## Documentation

- [ ] Relevant docs updated (docs/ folder, README, etc.)
closes #818 