### PR TITLE
fix: correct ClaimBurn decimal input validation and confirmation flow

### DIFF
--- a/apps/frontend/src/components/claim-burn.tsx
+++ b/apps/frontend/src/components/claim-burn.tsx
@@ -98,7 +98,7 @@ export function ClaimBurn({
 
   function handleRequestSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    if (!isValidAmount(amount)) {
+    if (!isValidAmount(inputAmount)) {
       setStatus('error');
       setErrorMsg('Please enter a valid amount greater than 0.');
       setTxHash(null);
@@ -110,6 +110,7 @@ export function ClaimBurn({
       setTxHash(null);
       return;
     }
+    setConfirmAmount(inputAmount);
     setStatus('confirm');
   }
 
@@ -143,7 +144,7 @@ export function ClaimBurn({
 
   const isPending = status === 'pending';
   const showConfirm = status === 'confirm';
-  const valid = isValidAmount(amount);
+  const valid = isValidAmount(inputAmount);
 
   // ── Wallet state screens ──────────────────────────────────────────
 
@@ -210,12 +211,12 @@ export function ClaimBurn({
                 type="number"
                 min="0"
                 step="any"
-                value={amount}
+                value={inputAmount}
                 onChange={handleAmountChange}
                 disabled
                 placeholder="0.00"
                 data-testid="amount-input"
-                aria-invalid={amount !== '' && !valid}
+                aria-invalid={inputAmount !== '' && !valid}
                 aria-label={`${mode === 'claim' ? 'Claim' : 'Burn'} amount`}
                 aria-describedby={status === 'error' ? 'claim-burn-error' : undefined}
                 className="focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
@@ -368,7 +369,7 @@ export function ClaimBurn({
           aria-label={`Confirm ${mode}`}
         >
           <p className="dark:text-slate-100 mb-4 text-base font-semibold text-slate-900">
-            {mode === 'claim' ? 'Claim' : 'Burn'} <strong>{amount}</strong> {tokenSymbol}?
+            {mode === 'claim' ? 'Claim' : 'Burn'} <strong>{confirmAmount}</strong> {tokenSymbol}?
           </p>
           <div className="grid grid-cols-2 gap-3">
             <button
@@ -404,15 +405,15 @@ export function ClaimBurn({
             <input
               ref={amountInputRef}
               id="amount-input"
-              type="number"
-              min="0"
-              step="any"
+              type="text"
+              inputMode="decimal"
+              pattern="^[0-9]*(?:[.,][0-9]*)?$"
               value={inputAmount}
               onChange={handleAmountChange}
               disabled={isPending}
               placeholder="0.00"
               data-testid="amount-input"
-              aria-invalid={amount !== '' && !valid}
+              aria-invalid={inputAmount !== '' && !valid}
               aria-label={`${mode === 'claim' ? 'Claim' : 'Burn'} amount`}
               aria-describedby={status === 'error' ? 'claim-burn-error' : undefined}
               className="focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
@@ -420,18 +421,17 @@ export function ClaimBurn({
             {balance != null && (
               <button
                 type="button"
-                className="btn-max focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
                 onClick={handleMax}
                 disabled={isPending}
                 data-testid="max-btn"
                 aria-label="Use maximum balance"
-                className="dark:bg-slate-800 dark:border-slate-600 dark:text-violet-400 dark:hover:bg-slate-700 shrink-0 rounded-lg border border-slate-300 bg-slate-50 px-3 py-2 text-sm font-semibold text-violet-600 transition-colors hover:bg-violet-50 disabled:cursor-not-allowed disabled:opacity-50"
+                className="btn-max dark:bg-slate-800 dark:border-slate-600 dark:text-violet-400 dark:hover:bg-slate-700 shrink-0 rounded-lg border border-slate-300 bg-slate-50 px-3 py-2 text-sm font-semibold text-violet-600 transition-colors hover:bg-violet-50 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Max
               </button>
             )}
           </div>
-          {amount !== '' && !valid && (
+          {inputAmount !== '' && !valid && (
             <p className="text-sm text-red-600 dark:text-red-400" data-testid="amount-error">
               Please enter a valid positive amount
             </p>

--- a/apps/frontend/tests/claim-burn.test.tsx
+++ b/apps/frontend/tests/claim-burn.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
 import { ClaimBurn } from '../src/components/claim-burn';
 import { ToastProvider } from '../src/components/Toast';
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(<ToastProvider>{ui}</ToastProvider>);
+}
 
 describe('ClaimBurn — wallet states', () => {
   it('shows checking/connecting spinner while loading', () => {
@@ -111,10 +116,11 @@ describe('ClaimBurn — confirmation flow', () => {
     expect(screen.queryByTestId('confirm-overlay')).not.toBeInTheDocument();
   });
 
-  it('shows amount in confirmation text', () => {
+  it('shows amount in confirmation text', async () => {
     renderWithProviders(<ClaimBurn walletState="connected" />);
-    fireEvent.change(screen.getByTestId('amount-input'), { target: { value: '42.5' } });
+    await userEvent.type(screen.getByTestId('amount-input'), '42.5');
     fireEvent.click(screen.getByTestId('submit-btn'));
+    await waitFor(() => expect(screen.getByTestId('confirm-overlay')).toBeInTheDocument());
     expect(screen.getByTestId('confirm-overlay')).toHaveTextContent('42.5');
   });
 });
@@ -122,16 +128,17 @@ describe('ClaimBurn — confirmation flow', () => {
 describe('ClaimBurn — submit and error handling', () => {
   it('calls onClaim with entered amount on submit', async () => {
     const onClaim = vi.fn().mockResolvedValue(undefined);
-    render(<ClaimBurn walletState="connected" onClaim={onClaim} />);
-    fireEvent.change(screen.getByTestId('amount-input'), { target: { value: '12.5' } });
+    renderWithProviders(<ClaimBurn walletState="connected" onClaim={onClaim} />);
+    await userEvent.type(screen.getByTestId('amount-input'), '12.5');
     fireEvent.click(screen.getByTestId('submit-btn'));
+    await waitFor(() => expect(screen.getByTestId('confirm-overlay')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('confirm-btn'));
     await waitFor(() => expect(onClaim).toHaveBeenCalledTimes(1));
     expect(onClaim).toHaveBeenCalledWith('12.5');
   });
 
   it('disables the submit button when wallet is disconnected', () => {
-    render(<ClaimBurn walletState="disconnected" />);
+    renderWithProviders(<ClaimBurn walletState="disconnected" />);
     expect(screen.getByTestId('wallet-disconnected')).toBeInTheDocument();
     expect(screen.getByTestId('submit-btn')).toBeDisabled();
   });
@@ -140,8 +147,9 @@ describe('ClaimBurn — submit and error handling', () => {
     const onBurn = vi.fn().mockResolvedValue(undefined);
     renderWithProviders(<ClaimBurn walletState="connected" onBurn={onBurn} />);
     fireEvent.click(screen.getByTestId('toggle-burn'));
-    fireEvent.change(screen.getByTestId('amount-input'), { target: { value: '5' } });
+    await userEvent.type(screen.getByTestId('amount-input'), '5');
     fireEvent.click(screen.getByTestId('submit-btn'));
+    await waitFor(() => expect(screen.getByTestId('confirm-overlay')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('confirm-btn'));
     await waitFor(() => expect(screen.getByTestId('success-msg')).toBeInTheDocument());
     expect(onBurn).toHaveBeenCalledWith('5');
@@ -171,27 +179,27 @@ describe('ClaimBurn — submit and error handling', () => {
 
 describe('ClaimBurn — input validation', () => {
   it('shows error and disables submit when amount is empty', () => {
-    render(<ClaimBurn walletState="connected" />);
+    renderWithProviders(<ClaimBurn walletState="connected" />);
     expect(screen.getByTestId('submit-btn')).toBeDisabled();
     expect(screen.queryByTestId('amount-error')).not.toBeInTheDocument();
   });
 
   it('shows error and disables submit when amount is zero', () => {
-    render(<ClaimBurn walletState="connected" />);
+    renderWithProviders(<ClaimBurn walletState="connected" />);
     fireEvent.change(screen.getByTestId('amount-input'), { target: { value: '0' } });
     expect(screen.getByTestId('submit-btn')).toBeDisabled();
     expect(screen.getByTestId('amount-error')).toBeInTheDocument();
   });
 
   it('shows error and disables submit when amount is negative', () => {
-    render(<ClaimBurn walletState="connected" />);
+    renderWithProviders(<ClaimBurn walletState="connected" />);
     fireEvent.change(screen.getByTestId('amount-input'), { target: { value: '-5' } });
     expect(screen.getByTestId('submit-btn')).toBeDisabled();
     expect(screen.getByTestId('amount-error')).toBeInTheDocument();
   });
 
   it('shows error and disables submit when amount is non-numeric', () => {
-    render(<ClaimBurn walletState="connected" />);
+    renderWithProviders(<ClaimBurn walletState="connected" />);
     fireEvent.change(screen.getByTestId('amount-input'), { target: { value: 'abc' } });
     expect(screen.getByTestId('submit-btn')).toBeDisabled();
     expect(screen.getByTestId('amount-error')).toBeInTheDocument();
@@ -200,24 +208,24 @@ describe('ClaimBurn — input validation', () => {
 
 describe('ClaimBurn — max balance button', () => {
   it('renders max button when balance is provided', () => {
-    render(<ClaimBurn walletState="connected" balance="100.5" />);
+    renderWithProviders(<ClaimBurn walletState="connected" balance="100.5" />);
     expect(screen.getByTestId('max-btn')).toBeInTheDocument();
   });
 
   it('does not render max button when balance is null', () => {
-    render(<ClaimBurn walletState="connected" />);
+    renderWithProviders(<ClaimBurn walletState="connected" />);
     expect(screen.queryByTestId('max-btn')).not.toBeInTheDocument();
   });
 
   it('sets amount input to balance when max button is clicked', () => {
-    render(<ClaimBurn walletState="connected" balance="50" />);
+    renderWithProviders(<ClaimBurn walletState="connected" balance="50" />);
     fireEvent.click(screen.getByTestId('max-btn'));
     expect(screen.getByTestId('amount-input')).toHaveValue('50');
   });
 
   it('disables max button while pending', async () => {
     const onClaim = vi.fn().mockResolvedValue(undefined);
-    render(<ClaimBurn walletState="connected" balance="10" onClaim={onClaim} />);
+    renderWithProviders(<ClaimBurn walletState="connected" balance="10" onClaim={onClaim} />);
     fireEvent.change(screen.getByTestId('amount-input'), { target: { value: '10' } });
     fireEvent.click(screen.getByTestId('submit-btn'));
     fireEvent.click(screen.getByTestId('confirm-btn'));
@@ -227,7 +235,7 @@ describe('ClaimBurn — max balance button', () => {
 
   it('does not call onClaim when form is submitted while disconnected', () => {
     const onClaim = vi.fn();
-    render(<ClaimBurn walletState="disconnected" onClaim={onClaim} />);
+    renderWithProviders(<ClaimBurn walletState="disconnected" onClaim={onClaim} />);
     fireEvent.submit(screen.getByTestId('claim-burn-form'));
     expect(onClaim).not.toHaveBeenCalled();
   });
@@ -235,18 +243,18 @@ describe('ClaimBurn — max balance button', () => {
 
 describe('ClaimBurn — accessibility', () => {
   it('has aria-label on switch-network button', () => {
-    render(<ClaimBurn walletState="wrongNetwork" expectedNetwork="testnet" />);
+    renderWithProviders(<ClaimBurn walletState="wrongNetwork" expectedNetwork="testnet" />);
     expect(screen.getByTestId('switch-network-btn')).toHaveAttribute('aria-label');
   });
 
   it('has aria-label on retry-connect button', () => {
-    render(<ClaimBurn walletState="error" />);
+    renderWithProviders(<ClaimBurn walletState="error" />);
     expect(screen.getByTestId('retry-connect-btn')).toHaveAttribute('aria-label');
   });
 
   it('input has aria-describedby when error is shown', async () => {
     const onClaim = vi.fn().mockRejectedValue(new Error('Transaction failed'));
-    render(<ClaimBurn walletState="connected" onClaim={onClaim} />);
+    renderWithProviders(<ClaimBurn walletState="connected" onClaim={onClaim} />);
     fireEvent.change(screen.getByTestId('amount-input'), { target: { value: '10' } });
     fireEvent.click(screen.getByTestId('submit-btn'));
     fireEvent.click(screen.getByTestId('confirm-btn'));
@@ -255,7 +263,7 @@ describe('ClaimBurn — accessibility', () => {
   });
 
   it('confirm overlay has dialog role and aria-modal', () => {
-    render(<ClaimBurn walletState="connected" />);
+    renderWithProviders(<ClaimBurn walletState="connected" />);
     fireEvent.change(screen.getByTestId('amount-input'), { target: { value: '10' } });
     fireEvent.click(screen.getByTestId('submit-btn'));
     const overlay = screen.getByTestId('confirm-overlay');
@@ -264,7 +272,7 @@ describe('ClaimBurn — accessibility', () => {
   });
 
   it('toggle buttons reflect state with aria-pressed', () => {
-    render(<ClaimBurn walletState="connected" />);
+    renderWithProviders(<ClaimBurn walletState="connected" />);
     expect(screen.getByTestId('toggle-claim')).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByTestId('toggle-burn')).toHaveAttribute('aria-pressed', 'false');
     fireEvent.click(screen.getByTestId('toggle-burn'));
@@ -273,7 +281,7 @@ describe('ClaimBurn — accessibility', () => {
   });
 
   it('focus ring classes are present on submit button', () => {
-    render(<ClaimBurn walletState="connected" />);
+    renderWithProviders(<ClaimBurn walletState="connected" />);
     const submitBtn = screen.getByTestId('submit-btn');
     expect(submitBtn.className).toContain('focus-visible:ring-2');
     expect(submitBtn.className).toContain('focus-visible:ring-emerald-500');


### PR DESCRIPTION
Closes #861
Closes #857
Closes #859
Closes #858



This PR fixes ClaimBurn frontend validation by using the controlled input state consistently, allowing decimal values in the connected amount input, and ensuring the confirmation overlay displays the entered amount. Relevant tests were updated and verified in apps/frontend/tests/claim-burn.test.tsx.