### PR TITLE
feat(escrow): add stake limits, TTL extension, and get_oracle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "contract-registry"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -34,6 +34,8 @@ use soroban_sdk::contracterror;
 /// | 21   | MatchTimedOut         | match has already timed out; use claim_timeout to reclaim funds |
 /// | 20   | DisputeWindowActive   | finalize_result called before the dispute window has expired |
 /// | 21   | MatchTimedOut         | match has already timed out; use claim_timeout to reclaim funds |
+/// | 22   | StakeTooLow           | stake_amount is below the minimum threshold                  |
+/// | 23   | StakeTooHigh          | stake_amount exceeds the maximum cap                         |
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
@@ -108,4 +110,12 @@ pub enum Error {
     /// [E021] The match has already been active for longer than `TIMEOUT_LEDGERS` without an
     /// oracle result. The match is effectively timed out; players should call `claim_timeout`.
     MatchTimedOut = 21,
+
+    /// [E022] The `stake_amount` is below the minimum threshold (`MIN_STAKE`).
+    /// Zero and negative amounts are also rejected through this error.
+    StakeTooLow = 22,
+
+    /// [E023] The `stake_amount` exceeds the maximum allowed cap (`MAX_STAKE`).
+    /// Prevents a single match from locking unbounded funds in escrow.
+    StakeTooHigh = 23,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -63,6 +63,26 @@ use types::{DataKey, Match, MatchState, OptionalWinner, Platform, Winner};
 /// ~30 days at 5s/ledger. Used as both the TTL threshold and the extend-to value.
 const MATCH_TTL_LEDGERS: u32 = 518_400;
 
+/// Minimum stake amount in the smallest token unit (1 stroop).
+/// Prevents economically meaningless zero-stake matches.
+const MIN_STAKE: i128 = 1;
+
+/// Maximum stake amount in the smallest token unit.
+/// Prevents a single match from locking unbounded funds in escrow,
+/// concentrating risk, and amplifying the impact of any exploit.
+const MAX_STAKE: i128 = 10_000_000_000_000;
+
+/// Instance-storage TTL threshold (~30 days at 5s/ledger).
+/// Instance entries (oracle, admin, token, paused, match_count) are
+/// extended to this many ledgers from the current ledger on every write.
+/// Without this, metadata entries would expire and the contract would
+/// become non-functional with storage-not-found errors.
+const INSTANCE_LIFETIME_THRESHOLD: u32 = 518_400;
+
+/// The number of ledgers to extend instance-storage entries to.
+/// Uses the same ~30-day window as persistent match storage.
+const INSTANCE_BUMP_AMOUNT: u32 = 518_400;
+
 /// Maximum allowed byte length for a game_id string.
 const MAX_GAME_ID_LEN: u32 = 64;
 
@@ -123,6 +143,9 @@ impl EscrowContract {
         env.storage().instance().set(&DataKey::Token, &token);
         env.storage().instance().set(&DataKey::MatchCount, &0u64);
         env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         Ok(())
     }
 
@@ -135,6 +158,9 @@ impl EscrowContract {
             .ok_or(Error::Unauthorized)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Oracle, &new_oracle);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         env.events().publish(
             (Symbol::new(&env, "admin"), symbol_short!("oracle")),
             new_oracle,
@@ -151,6 +177,9 @@ impl EscrowContract {
             .ok_or(Error::Unauthorized)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &true);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         env.events()
             .publish((Symbol::new(&env, "admin"), symbol_short!("paused")), ());
         Ok(())
@@ -165,6 +194,9 @@ impl EscrowContract {
             .ok_or(Error::Unauthorized)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         env.events()
             .publish((Symbol::new(&env, "admin"), symbol_short!("unpaused")), ());
         Ok(())
@@ -185,8 +217,11 @@ impl EscrowContract {
         if Self::is_paused(&env) {
             return Err(Error::ContractPaused);
         }
-        if stake_amount <= 0 {
-            return Err(Error::InvalidAmount);
+        if stake_amount < MIN_STAKE {
+            return Err(Error::StakeTooLow);
+        }
+        if stake_amount > MAX_STAKE {
+            return Err(Error::StakeTooHigh);
         }
         if player1 == player2 {
             return Err(Error::InvalidPlayers);
@@ -227,8 +262,9 @@ impl EscrowContract {
             created_ledger: env.ledger().sequence(),
             activated_ledger: 0,
             pending_result_ledger: 0,
-            pending_winner: None,
+            pending_winner: OptionalWinner::None,
             completed_ledger: None,
+            cancelled_ledger: None,
         };
 
         env.storage().persistent().set(&DataKey::Match(id), &m);
@@ -247,6 +283,9 @@ impl EscrowContract {
         );
         let next_id = id.checked_add(1).ok_or(Error::Overflow)?;
         env.storage().instance().set(&DataKey::MatchCount, &next_id);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
 
         env.events().publish(
             (Symbol::new(&env, "match"), symbol_short!("created")),
@@ -736,6 +775,14 @@ impl EscrowContract {
         );
 
         Ok(())
+    }
+
+    /// Read the registered oracle address.
+    pub fn get_oracle(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Oracle)
+            .expect("oracle not initialized")
     }
 
     /// Read a match by ID.

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1,7 +1,12 @@
 extern crate std;
 use super::*;
 use soroban_sdk::{
-    testutils::{storage::Persistent as _, Address as _, Events},
+    testutils::{
+        storage::Instance as _,
+        storage::Persistent as _,
+        Address as _,
+        Events,
+    },
     token::{Client as TokenClient, StellarAssetClient},
     vec, Address, Env, IntoVal, String, Symbol, TryFromVal,
 };
@@ -678,17 +683,19 @@ fn test_double_initialize_fails() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #10)")]
 fn test_create_match_zero_stake_fails() {
     let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
-    client.create_match(
-        &player1,
-        &player2,
-        &0,
-        &token,
-        &String::from_str(&env, "zero_stake"),
-        &Platform::Lichess,
+    assert_eq!(
+        client.try_create_match(
+            &player1,
+            &player2,
+            &0,
+            &token,
+            &String::from_str(&env, "zero_stake"),
+            &Platform::Lichess,
+        ),
+        Err(Ok(Error::StakeTooLow))
     );
 }
 
@@ -1661,7 +1668,7 @@ fn test_create_match_negative_stake_fails() {
             &String::from_str(&env, "neg_stake"),
             &Platform::Lichess,
         ),
-        Err(Ok(Error::InvalidAmount))
+        Err(Ok(Error::StakeTooLow))
     );
 }
 
@@ -2096,4 +2103,65 @@ fn test_create_match_valid_platforms_accepted() {
         &String::from_str(&env, "chessdotcom-game-1"), &Platform::ChessDotCom,
     );
     assert_eq!(client.get_match(&id2).platform, Platform::ChessDotCom);
+}
+
+// Issue #794: get_oracle returns the address passed to initialize
+#[test]
+fn test_get_oracle_returns_initialized_address() {
+    let (env, contract_id, oracle, _player1, _player2, _token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    assert_eq!(client.get_oracle(), oracle);
+}
+
+// Issue #792: stake amount above MAX_STAKE is rejected
+#[test]
+fn test_create_match_stake_too_high_fails() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    assert_eq!(
+        client.try_create_match(
+            &player1,
+            &player2,
+            &(crate::MAX_STAKE + 1),
+            &token,
+            &String::from_str(&env, "too_high"),
+            &Platform::Lichess,
+        ),
+        Err(Ok(Error::StakeTooHigh))
+    );
+}
+
+// Issue #791: stake amount below MIN_STAKE (e.g. zero) is rejected as StakeTooLow
+#[test]
+fn test_create_match_stake_below_min_fails() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    assert_eq!(
+        client.try_create_match(
+            &player1,
+            &player2,
+            &0,
+            &token,
+            &String::from_str(&env, "below_min"),
+            &Platform::Lichess,
+        ),
+        Err(Ok(Error::StakeTooLow))
+    );
+}
+
+// Issue #793: instance storage TTL is extended after initialize
+#[test]
+fn test_instance_ttl_extended_on_initialize() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_addr = token_id.address();
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    client.initialize(&oracle, &admin, &token_addr);
+
+    let instance_ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
+    assert!(instance_ttl >= crate::INSTANCE_LIFETIME_THRESHOLD);
 }

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -256,7 +256,7 @@ pub struct Match {
     /// admin via [`override_result`](crate::EscrowContract::override_result).
     /// Used by [`finalize_result`](crate::EscrowContract::finalize_result) to
     /// determine the payout. `None` when no result is pending.
-    pub pending_winner: Option<Winner>,
+    pub pending_winner: OptionalWinner,
 
     /// The ledger sequence number at which this match was completed and the
     /// payout was executed.
@@ -265,6 +265,13 @@ pub struct Match {
     /// [`finalize_result`](crate::EscrowContract::finalize_result) when the match
     /// transitions to [`MatchState::Completed`]. `None` for all other states.
     pub completed_ledger: Option<u32>,
+
+    /// The ledger sequence number at which this match was cancelled.
+    ///
+    /// Set to `Some(env.ledger().sequence())` by
+    /// [`cancel_match`](crate::EscrowContract::cancel_match) when the match
+    /// transitions to [`MatchState::Cancelled`]. `None` for all other states.
+    pub cancelled_ledger: Option<u32>,
 }
 
 /// Storage keys used by the escrow contract.


### PR DESCRIPTION
Closes #791, 
Closes #792, 
Closes #793, 
Closes #794

### #791 — Minimum stake floor
- Added `MIN_STAKE` constant (1 stroop)
- `create_match` returns `Error::StakeTooLow` when `stake_amount < MIN_STAKE`
- Prevents zero/negative stake matches that pollute state

### #792 — Maximum stake cap
- Added `MAX_STAKE` constant (10 trillion stroops)
- `create_match` returns `Error::StakeTooHigh` when `stake_amount > MAX_STAKE`
- Prevents unbounded funds in a single match

### #793 — Instance storage TTL extension
- Added `INSTANCE_LIFETIME_THRESHOLD` and `INSTANCE_BUMP_AMOUNT` constants (~30 days)
- `initialize` now calls `extend_ttl` after writing all instance entries
- TTL also extended in `update_oracle`, `pause`, `unpause`, and `create_match`
- Prevents metadata expiry that would make the contract non-functional

### #794 — `get_oracle` read-only function
- Added `fn get_oracle(env: Env) -> Address` to the public contract API
- Provides off-chain services a clean versioned surface to read the oracle address

### Pre-existing bug fixes
- Fixed `Match.pending_winner` type mismatch (`Option<Winner>` → `OptionalWinner`)
- Added missing `cancelled_ledger` field to the `Match` struct