### PR TITLE
fix(escrow): validate token address in create_match against initializ…

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -32,8 +32,7 @@ use soroban_sdk::contracterror;
 /// | 19   | InsufficientAllowance | player has not approved sufficient token allowance |
 /// | 20   | DisputeWindowActive   | finalize_result called before the dispute window has expired |
 /// | 21   | MatchTimedOut         | match has already timed out; use claim_timeout to reclaim funds |
-/// | 20   | DisputeWindowActive   | finalize_result called before the dispute window has expired |
-/// | 21   | MatchTimedOut         | match has already timed out; use claim_timeout to reclaim funds |
+/// | 22   | InvalidToken          | the provided token address does not match the initialized token |
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
@@ -108,4 +107,8 @@ pub enum Error {
     /// [E021] The match has already been active for longer than `TIMEOUT_LEDGERS` without an
     /// oracle result. The match is effectively timed out; players should call `claim_timeout`.
     MatchTimedOut = 21,
+
+    /// [E022] The provided token address does not match the token set during `initialize`.
+    /// `create_match` requires the token to match the contract's configured token.
+    InvalidToken = 22,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -203,6 +203,15 @@ impl EscrowContract {
             return Err(Error::DuplicateGameId);
         }
 
+        let stored_token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Token)
+            .ok_or(Error::Unauthorized)?;
+        if token != stored_token {
+            return Err(Error::InvalidToken);
+        }
+
         let id: u64 = env
             .storage()
             .instance()
@@ -227,7 +236,8 @@ impl EscrowContract {
             created_ledger: env.ledger().sequence(),
             activated_ledger: 0,
             pending_result_ledger: 0,
-            pending_winner: None,
+            pending_winner: OptionalWinner::None,
+            cancelled_ledger: None,
             completed_ledger: None,
         };
 

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -784,6 +784,29 @@ fn test_create_match_empty_game_id_fails() {
 }
 
 #[test]
+fn test_create_match_wrong_token_fails() {
+    let (env, contract_id, _oracle, player1, player2, _token, admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // Register a different token contract
+    let wrong_token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    assert_eq!(
+        client.try_create_match(
+            &player1,
+            &player2,
+            &100,
+            &wrong_token,
+            &String::from_str(&env, "wrong_token"),
+            &Platform::Lichess,
+        ),
+        Err(Ok(Error::InvalidToken))
+    );
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #4)")]
 fn test_unauthorized_player_cannot_cancel() {
     let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -256,7 +256,14 @@ pub struct Match {
     /// admin via [`override_result`](crate::EscrowContract::override_result).
     /// Used by [`finalize_result`](crate::EscrowContract::finalize_result) to
     /// determine the payout. `None` when no result is pending.
-    pub pending_winner: Option<Winner>,
+    pub pending_winner: OptionalWinner,
+
+    /// The ledger sequence number at which this match was cancelled.
+    ///
+    /// Set to `Some(env.ledger().sequence())` by
+    /// [`cancel_match`](crate::EscrowContract::cancel_match) when the match
+    /// transitions to [`MatchState::Cancelled`]. `None` for all other states.
+    pub cancelled_ledger: Option<u32>,
 
     /// The ledger sequence number at which this match was completed and the
     /// payout was executed.


### PR DESCRIPTION
## Summary

`create_match` now validates that the provided `token` matches the token address set during `initialize`. A mismatched token is rejected with `Error::InvalidToken`.

## Changes

- **errors.rs**: Added `InvalidToken = 22` variant
- **lib.rs** (`create_match`): Loads `stored_token` from `DataKey::Token` instance storage and returns `Error::InvalidToken` if `token != stored_token`
- **tests.rs**: Added `test_create_match_wrong_token_fails` — registers a second token contract and asserts `InvalidToken` is returned
- **types.rs**: Added missing `cancelled_ledger: Option<u32>` field to the `Match` struct (pre-existing compilation blocker)

## Testing

cargo test test_create_match_wrong_token_fails
   ... ok

Closes #798