### PR TITLE
test: add property-based, E2E, and UI tests (#1122–#1125)

### DIFF
--- a/apps/frontend/src/components/MatchStatus.tsx
+++ b/apps/frontend/src/components/MatchStatus.tsx
@@ -3,6 +3,9 @@ import { Networks, rpc } from '@stellar/stellar-sdk';
 
 type MatchState = 'Pending' | 'Active' | 'PendingResult' | 'Completed' | 'Cancelled';
 
+/** Reason a match entered the Cancelled terminal state. */
+type CancellationReason = 'cancelled_by_player' | 'timed_out';
+
 interface MatchData {
   id: string;
   state: MatchState;
@@ -13,6 +16,14 @@ interface MatchData {
   platform: 'lichess' | 'chesscom';
   gameId: string;
   winner?: 'Player1' | 'Player2' | 'Draw';
+  /** Which player cancelled the match (Stellar address), if applicable. */
+  cancelledBy?: string;
+  /** How the match was cancelled: by a player or via the timeout mechanism. */
+  cancellationReason?: CancellationReason;
+  /** Whether player1 had already deposited before cancellation. */
+  player1Deposited?: boolean;
+  /** Whether player2 had already deposited before cancellation. */
+  player2Deposited?: boolean;
 }
 
 interface MatchStatusProps {
@@ -209,15 +220,60 @@ export function MatchStatus({
           </div>
         );
 
-      case 'Cancelled':
+      case 'Cancelled': {
+        const isTimedOut = matchData.cancellationReason === 'timed_out';
+        const cancelledByAddress = matchData.cancelledBy;
+
+        let cancellationDetail: string;
+        if (isTimedOut) {
+          cancellationDetail =
+            'The match timed out because the oracle did not submit a result within the allowed window.';
+        } else if (cancelledByAddress) {
+          const isP1 = cancelledByAddress === matchData.player1;
+          const canceller = isP1 ? 'Player 1' : 'Player 2';
+          cancellationDetail = `This match was cancelled by ${canceller} (${cancelledByAddress.slice(0, 4)}...${cancelledByAddress.slice(-4)}).`;
+        } else {
+          cancellationDetail = 'This match has been cancelled.';
+        }
+
+        const p1Refunded = matchData.player1Deposited ?? false;
+        const p2Refunded = matchData.player2Deposited ?? false;
+        const anyRefund = p1Refunded || p2Refunded;
+
         return (
           <div className="state-content cancelled" data-testid="state-cancelled">
             <h3 className="state-title">Cancelled</h3>
-            <p className="state-description">
-              This match has been cancelled. Any deposited stakes have been refunded.
+            <p
+              className="state-description"
+              data-testid={isTimedOut ? 'cancel-reason-timeout' : 'cancel-reason-player'}
+            >
+              {cancellationDetail}
             </p>
+            {anyRefund && (
+              <div className="refund-info" data-testid="refund-info">
+                <p className="refund-title">Refunds issued:</p>
+                <ul className="refund-list">
+                  {p1Refunded && (
+                    <li data-testid="refund-player1">
+                      Player 1 refunded {matchData.stakeAmount} {matchData.token.toUpperCase()}
+                    </li>
+                  )}
+                  {p2Refunded && (
+                    <li data-testid="refund-player2">
+                      Player 2 refunded {matchData.stakeAmount} {matchData.token.toUpperCase()}
+                    </li>
+                  )}
+                </ul>
+              </div>
+            )}
+            {!anyRefund && (
+              <p className="no-refund" data-testid="no-refund-info">
+                No stakes were deposited; no refunds were necessary.
+              </p>
+            )}
           </div>
         );
+      }
     }
   };
 

--- a/apps/frontend/tests/MatchStatus.test.tsx
+++ b/apps/frontend/tests/MatchStatus.test.tsx
@@ -129,3 +129,241 @@ describe('MatchStatus — state rendering with match data', () => {
     });
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #1125 — Cancelled state UI tests with cancellation reason paths
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Covers both cancellation paths:
+//   1. cancelled_by_player — a player explicitly called cancel_match
+//   2. timed_out           — the match timed out without an oracle result
+//
+// Also verifies the refund display for:
+//   - No deposits made (no refund section)
+//   - Only player1 deposited (player1 refund only)
+//   - Both players deposited (both refunds shown)
+
+describe('MatchStatus — Cancelled state (cancelled by player)', () => {
+  it('shows cancel-reason-player section when cancelled by player1', async () => {
+    const onFetchMatch = vi.fn().mockResolvedValue({
+      id: '42',
+      state: 'Cancelled',
+      player1: 'GPLAYER1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      player2: 'GPLAYER2ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ',
+      stakeAmount: '100',
+      token: 'xlm',
+      platform: 'lichess',
+      gameId: 'cancel-game-1',
+      cancellationReason: 'cancelled_by_player',
+      cancelledBy: 'GPLAYER1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      player1Deposited: false,
+      player2Deposited: false,
+    });
+
+    render(<MatchStatus matchId="42" onFetchMatch={onFetchMatch} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('state-cancelled')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('cancel-reason-player')).toBeInTheDocument();
+    expect(screen.getByTestId('cancel-reason-player').textContent).toMatch(/Player 1/i);
+    expect(screen.queryByTestId('cancel-reason-timeout')).not.toBeInTheDocument();
+  });
+
+  it('shows cancel-reason-player section when cancelled by player2', async () => {
+    const onFetchMatch = vi.fn().mockResolvedValue({
+      id: '43',
+      state: 'Cancelled',
+      player1: 'GPLAYER1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      player2: 'GPLAYER2ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ',
+      stakeAmount: '100',
+      token: 'xlm',
+      platform: 'lichess',
+      gameId: 'cancel-game-2',
+      cancellationReason: 'cancelled_by_player',
+      cancelledBy: 'GPLAYER2ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ',
+      player1Deposited: false,
+      player2Deposited: false,
+    });
+
+    render(<MatchStatus matchId="43" onFetchMatch={onFetchMatch} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('state-cancelled')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('cancel-reason-player')).toBeInTheDocument();
+    expect(screen.getByTestId('cancel-reason-player').textContent).toMatch(/Player 2/i);
+  });
+});
+
+describe('MatchStatus — Cancelled state (timed out)', () => {
+  it('shows cancel-reason-timeout section for timed_out cancellation', async () => {
+    const onFetchMatch = vi.fn().mockResolvedValue({
+      id: '44',
+      state: 'Cancelled',
+      player1: 'GPLAYER1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      player2: 'GPLAYER2ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ',
+      stakeAmount: '200',
+      token: 'xlm',
+      platform: 'lichess',
+      gameId: 'timeout-game-1',
+      cancellationReason: 'timed_out',
+      player1Deposited: true,
+      player2Deposited: true,
+    });
+
+    render(<MatchStatus matchId="44" onFetchMatch={onFetchMatch} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('state-cancelled')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('cancel-reason-timeout')).toBeInTheDocument();
+    expect(screen.getByTestId('cancel-reason-timeout').textContent).toMatch(/timed out/i);
+    expect(screen.queryByTestId('cancel-reason-player')).not.toBeInTheDocument();
+  });
+
+  it('shows refund info for both players when both deposited and match timed out', async () => {
+    const onFetchMatch = vi.fn().mockResolvedValue({
+      id: '45',
+      state: 'Cancelled',
+      player1: 'GPLAYER1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      player2: 'GPLAYER2ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ',
+      stakeAmount: '250',
+      token: 'usdc',
+      platform: 'chesscom',
+      gameId: 'timeout-game-2',
+      cancellationReason: 'timed_out',
+      player1Deposited: true,
+      player2Deposited: true,
+    });
+
+    render(<MatchStatus matchId="45" onFetchMatch={onFetchMatch} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('state-cancelled')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('refund-info')).toBeInTheDocument();
+    expect(screen.getByTestId('refund-player1')).toBeInTheDocument();
+    expect(screen.getByTestId('refund-player1').textContent).toMatch(/250/);
+    expect(screen.getByTestId('refund-player1').textContent).toMatch(/USDC/i);
+    expect(screen.getByTestId('refund-player2')).toBeInTheDocument();
+    expect(screen.getByTestId('refund-player2').textContent).toMatch(/250/);
+  });
+});
+
+describe('MatchStatus — Cancelled state (refund display)', () => {
+  it('shows only player1 refund when only player1 deposited', async () => {
+    const onFetchMatch = vi.fn().mockResolvedValue({
+      id: '46',
+      state: 'Cancelled',
+      player1: 'GPLAYER1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      player2: 'GPLAYER2ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ',
+      stakeAmount: '100',
+      token: 'xlm',
+      platform: 'lichess',
+      gameId: 'partial-dep-cancel',
+      cancellationReason: 'cancelled_by_player',
+      cancelledBy: 'GPLAYER2ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ',
+      player1Deposited: true,
+      player2Deposited: false,
+    });
+
+    render(<MatchStatus matchId="46" onFetchMatch={onFetchMatch} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('state-cancelled')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('refund-info')).toBeInTheDocument();
+    expect(screen.getByTestId('refund-player1')).toBeInTheDocument();
+    // player2 had no deposit — no refund entry
+    expect(screen.queryByTestId('refund-player2')).not.toBeInTheDocument();
+  });
+
+  it('shows no-refund-info section when no deposits were made', async () => {
+    const onFetchMatch = vi.fn().mockResolvedValue({
+      id: '47',
+      state: 'Cancelled',
+      player1: 'GPLAYER1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      player2: 'GPLAYER2ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ',
+      stakeAmount: '100',
+      token: 'xlm',
+      platform: 'lichess',
+      gameId: 'no-dep-cancel',
+      cancellationReason: 'cancelled_by_player',
+      cancelledBy: 'GPLAYER1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      player1Deposited: false,
+      player2Deposited: false,
+    });
+
+    render(<MatchStatus matchId="47" onFetchMatch={onFetchMatch} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('state-cancelled')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('no-refund-info')).toBeInTheDocument();
+    expect(screen.queryByTestId('refund-info')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('refund-player1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('refund-player2')).not.toBeInTheDocument();
+  });
+
+  it('shows both player1 and player2 refunds when both deposited before player-cancel', async () => {
+    const onFetchMatch = vi.fn().mockResolvedValue({
+      id: '48',
+      state: 'Cancelled',
+      player1: 'GPLAYER1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      player2: 'GPLAYER2ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ',
+      stakeAmount: '300',
+      token: 'xlm',
+      platform: 'lichess',
+      gameId: 'both-dep-cancel',
+      cancellationReason: 'cancelled_by_player',
+      cancelledBy: 'GPLAYER1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      player1Deposited: true,
+      player2Deposited: true,
+    });
+
+    render(<MatchStatus matchId="48" onFetchMatch={onFetchMatch} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('state-cancelled')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('refund-info')).toBeInTheDocument();
+    expect(screen.getByTestId('refund-player1')).toBeInTheDocument();
+    expect(screen.getByTestId('refund-player2')).toBeInTheDocument();
+    expect(screen.queryByTestId('no-refund-info')).not.toBeInTheDocument();
+  });
+
+  it('renders the Cancelled state without cancellationReason (generic fallback)', async () => {
+    // When cancellationReason is not provided, a generic message is shown
+    const onFetchMatch = vi.fn().mockResolvedValue({
+      id: '49',
+      state: 'Cancelled',
+      player1: 'GPLAYER1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      player2: 'GPLAYER2ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ',
+      stakeAmount: '100',
+      token: 'xlm',
+      platform: 'lichess',
+      gameId: 'no-reason-cancel',
+    });
+
+    render(<MatchStatus matchId="49" onFetchMatch={onFetchMatch} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('state-cancelled')).toBeInTheDocument();
+    });
+
+    // Neither specific reason testid should be present
+    expect(screen.queryByTestId('cancel-reason-timeout')).not.toBeInTheDocument();
+    // Without cancelledBy, it falls back to the generic cancel-reason-player element
+    // with the generic "cancelled" message
+    expect(screen.getByTestId('cancel-reason-player')).toBeInTheDocument();
+    expect(screen.getByTestId('cancel-reason-player').textContent).toMatch(/cancelled/i);
+  });
+});

--- a/contracts/escrow/Cargo.toml
+++ b/contracts/escrow/Cargo.toml
@@ -11,3 +11,4 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = { version = "1.4.0", default-features = false, features = ["alloc"] }

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -1730,6 +1730,35 @@ fn test_submit_result_on_cancelled_match_fails() {
     );
 }
 
+// Issue #1124 — Explicit test: second deposit for the same player returns AlreadyFunded.
+//
+// The AlreadyFunded invariant is enforced independently for each player.
+// This test documents the expected behaviour for player2 so the idempotency
+// guarantee is visible for both participants.
+#[test]
+fn test_second_deposit_player2_returns_already_funded() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "already_funded_p2"),
+        &Platform::Lichess,
+    );
+
+    // Player2 deposits successfully
+    client.deposit(&id, &player2);
+    // Second call from the same player must be rejected
+    assert_eq!(
+        client.try_deposit(&id, &player2),
+        Err(Ok(Error::AlreadyFunded)),
+        "second deposit for player2 must return AlreadyFunded"
+    );
+}
+
 // Issue #33: Already-deposited player cannot deposit again
 #[test]
 fn test_double_deposit_same_player_fails() {
@@ -2261,4 +2290,333 @@ fn test_instance_ttl_extended_on_initialize() {
 
     let instance_ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
     assert!(instance_ttl >= crate::INSTANCE_LIFETIME_THRESHOLD);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Issue #1122 — Property-based tests for state machine transition invariants
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// These tests use proptest to generate exhaustive random call sequences and
+// assert that any operation issued in the wrong state is always rejected with
+// `Error::InvalidState`, `Error::MatchCancelled`, or `Error::MatchCompleted`,
+// ensuring the state machine cannot be subverted.
+//
+// Because proptest requires `std` and the contract is `#![no_std]`, the
+// property tests live in a separate sub-module gated on the `testutils`
+// feature.  They import the contract types directly and drive the standard
+// `EscrowContractClient` provided by the SDK.
+
+#[cfg(test)]
+mod proptest_state_machine {
+    extern crate std;
+
+    use super::*;
+    use proptest::prelude::*;
+    use soroban_sdk::{
+        testutils::Address as _,
+        token::{Client as TokenClient, StellarAssetClient},
+        Address, Env, String,
+    };
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    /// Build a minimal environment with the escrow contract initialised.
+    fn prop_setup() -> (Env, Address, Address, Address, Address, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let player1 = Address::generate(&env);
+        let player2 = Address::generate(&env);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_addr = token_id.address();
+        let asset_client = StellarAssetClient::new(&env, &token_addr);
+        asset_client.mint(&player1, &1_000);
+        asset_client.mint(&player2, &1_000);
+
+        let contract_id = env.register(EscrowContract, ());
+        let client = EscrowContractClient::new(&env, &contract_id);
+        client.initialize(&oracle, &admin, &token_addr);
+
+        let expiration = env.ledger().sequence() + 1_000_000;
+        let token_client = TokenClient::new(&env, &token_addr);
+        token_client.approve(&player1, &contract_id, &1_000, &expiration);
+        token_client.approve(&player2, &contract_id, &1_000, &expiration);
+
+        (env, contract_id, oracle, player1, player2, token_addr, admin)
+    }
+
+    // ── invariant 1: Completed is terminal ──────────────────────────────────
+
+    /// After a match reaches the `Completed` state any subsequent call to
+    /// `deposit`, `cancel_match`, or `submit_result` must return an error —
+    /// never silently succeed.
+    ///
+    /// We parametrise over which player wins so proptest can cover all three
+    /// `Winner` variants across many runs.
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(20))]
+
+        #[test]
+        fn prop_completed_is_terminal(winner_idx in 0usize..3) {
+            let (env, contract_id, oracle, player1, player2, token, _admin) = prop_setup();
+            let client = EscrowContractClient::new(&env, &contract_id);
+
+            let winners = [Winner::Player1, Winner::Player2, Winner::Draw];
+            let winner = winners[winner_idx].clone();
+
+            let id = client.create_match(
+                &player1,
+                &player2,
+                &100,
+                &token,
+                &String::from_str(&env, "prop-completed"),
+                &Platform::Lichess,
+            );
+            client.deposit(&id, &player1);
+            client.deposit(&id, &player2);
+
+            // Drive to PendingResult then advance past dispute window
+            client.submit_result(&id, &String::from_str(&env, "prop-completed"), &winner, &oracle);
+            // Advance ledger past the dispute window
+            env.ledger().set_sequence_number(env.ledger().sequence() + 17_281);
+            client.finalize_result(&id);
+
+            // After Completed: every mutating call must be rejected
+            assert_eq!(
+                client.get_match(&id).state,
+                MatchState::Completed,
+                "expected Completed state"
+            );
+
+            // deposit is rejected
+            let deposit_result = client.try_deposit(&id, &player1);
+            prop_assert!(
+                deposit_result.is_err(),
+                "deposit on Completed match must be rejected"
+            );
+
+            // cancel_match is rejected
+            let cancel_result = client.try_cancel_match(&id, &player1);
+            prop_assert!(
+                cancel_result.is_err(),
+                "cancel_match on Completed match must be rejected"
+            );
+
+            // submit_result is rejected
+            let submit_result = client.try_submit_result(
+                &id,
+                &String::from_str(&env, "prop-completed"),
+                &Winner::Player1,
+                &oracle,
+            );
+            prop_assert!(
+                submit_result.is_err(),
+                "submit_result on Completed match must be rejected"
+            );
+        }
+    }
+
+    // ── invariant 2: Cancelled is terminal ──────────────────────────────────
+
+    /// After a match reaches the `Cancelled` state any subsequent call to
+    /// `deposit`, `cancel_match`, or `submit_result` must return an error.
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(20))]
+
+        #[test]
+        fn prop_cancelled_is_terminal(cancel_with_deposit in proptest::bool::ANY) {
+            let (env, contract_id, oracle, player1, player2, token, _admin) = prop_setup();
+            let client = EscrowContractClient::new(&env, &contract_id);
+
+            let id = client.create_match(
+                &player1,
+                &player2,
+                &100,
+                &token,
+                &String::from_str(&env, "prop-cancelled"),
+                &Platform::Lichess,
+            );
+
+            if cancel_with_deposit {
+                client.deposit(&id, &player1);
+            }
+            client.cancel_match(&id, &player1);
+
+            assert_eq!(client.get_match(&id).state, MatchState::Cancelled);
+
+            // deposit is rejected
+            let deposit_result = client.try_deposit(&id, &player1);
+            prop_assert!(
+                deposit_result.is_err(),
+                "deposit on Cancelled match must be rejected"
+            );
+
+            // cancel_match is rejected
+            let cancel_result = client.try_cancel_match(&id, &player1);
+            prop_assert!(
+                cancel_result.is_err(),
+                "cancel_match on Cancelled match must be rejected"
+            );
+
+            // submit_result is rejected
+            let submit_result = client.try_submit_result(
+                &id,
+                &String::from_str(&env, "prop-cancelled"),
+                &Winner::Player1,
+                &oracle,
+            );
+            prop_assert!(
+                submit_result.is_err(),
+                "submit_result on Cancelled match must be rejected"
+            );
+        }
+    }
+
+    // ── invariant 3: Active → only valid exit is submit_result ───────────────
+
+    /// Once a match is `Active` (both players deposited), `cancel_match` must
+    /// always be rejected with `InvalidState` — the only valid exit from Active
+    /// is through the oracle path.
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(20))]
+
+        #[test]
+        fn prop_active_cancel_always_rejected(cancel_caller_is_p1 in proptest::bool::ANY) {
+            let (env, contract_id, _oracle, player1, player2, token, _admin) = prop_setup();
+            let client = EscrowContractClient::new(&env, &contract_id);
+
+            let id = client.create_match(
+                &player1,
+                &player2,
+                &100,
+                &token,
+                &String::from_str(&env, "prop-active-cancel"),
+                &Platform::Lichess,
+            );
+            client.deposit(&id, &player1);
+            client.deposit(&id, &player2);
+
+            assert_eq!(client.get_match(&id).state, MatchState::Active);
+
+            let caller = if cancel_caller_is_p1 { &player1 } else { &player2 };
+            let result = client.try_cancel_match(&id, caller);
+
+            prop_assert_eq!(
+                result,
+                Err(Ok(Error::InvalidState)),
+                "cancel_match on Active match must return InvalidState"
+            );
+        }
+    }
+
+    // ── invariant 4: submit_result only valid from Active ────────────────────
+
+    /// `submit_result` must return `InvalidState` when called on a match that
+    /// is in `Pending` or `Cancelled` state (covers non-Active starting states
+    /// via proptest).
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(20))]
+
+        #[test]
+        fn prop_submit_result_only_valid_from_active(
+            depositor_idx in 0usize..3,  // 0 = none, 1 = p1 only, 2 = p2 only
+        ) {
+            let (env, contract_id, oracle, player1, player2, token, _admin) = prop_setup();
+            let client = EscrowContractClient::new(&env, &contract_id);
+
+            // Use unique game IDs per run to avoid DuplicateGameId across repeated
+            // proptest cases within the same process.  We embed depositor_idx in
+            // the ID to ensure uniqueness.
+            let raw: &str = match depositor_idx {
+                0 => "prop-submit-none",
+                1 => "prop-submit-p1",
+                _ => "prop-submit-p2",
+            };
+            let game_id = String::from_str(&env, raw);
+
+            let id = client.create_match(
+                &player1,
+                &player2,
+                &100,
+                &token,
+                &game_id,
+                &Platform::Lichess,
+            );
+
+            match depositor_idx {
+                1 => { client.deposit(&id, &player1); }
+                2 => { client.deposit(&id, &player2); }
+                _ => {}
+            }
+
+            // Match is Pending (not Active) — submit_result must be rejected
+            let result = client.try_submit_result(
+                &id,
+                &game_id,
+                &Winner::Player1,
+                &oracle,
+            );
+            prop_assert!(
+                result.is_err(),
+                "submit_result must be rejected when match is not Active"
+            );
+            // Must be InvalidState, not some other error
+            prop_assert_eq!(
+                result,
+                Err(Ok(Error::InvalidState)),
+                "submit_result on non-Active match must return InvalidState"
+            );
+        }
+    }
+
+    // ── invariant 5: no operation accepted after terminal state ───────────────
+
+    /// Comprehensive sweep: for every reachable terminal state, assert that
+    /// ALL mutating operations are rejected.  This catches any future addition
+    /// to the API that might forget to guard against terminal states.
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(10))]
+
+        #[test]
+        fn prop_no_operation_accepted_in_terminal_state(
+            reach_completed in proptest::bool::ANY,
+        ) {
+            let (env, contract_id, oracle, player1, player2, token, _admin) = prop_setup();
+            let client = EscrowContractClient::new(&env, &contract_id);
+
+            let (game_str, terminal_state) = if reach_completed {
+                ("prop-terminal-completed", MatchState::Completed)
+            } else {
+                ("prop-terminal-cancelled", MatchState::Cancelled)
+            };
+            let game_id = String::from_str(&env, game_str);
+
+            let id = client.create_match(
+                &player1, &player2, &100, &token, &game_id, &Platform::Lichess,
+            );
+
+            if reach_completed {
+                client.deposit(&id, &player1);
+                client.deposit(&id, &player2);
+                client.submit_result(&id, &game_id, &Winner::Player1, &oracle);
+                env.ledger().set_sequence_number(env.ledger().sequence() + 17_281);
+                client.finalize_result(&id);
+            } else {
+                client.cancel_match(&id, &player1);
+            }
+
+            prop_assert_eq!(client.get_match(&id).state, terminal_state);
+
+            // Every mutating entry-point must be rejected
+            prop_assert!(client.try_deposit(&id, &player1).is_err());
+            prop_assert!(client.try_cancel_match(&id, &player1).is_err());
+            prop_assert!(
+                client.try_submit_result(&id, &game_id, &Winner::Player1, &oracle).is_err()
+            );
+            prop_assert!(client.try_finalize_result(&id).is_err());
+        }
+    }
 }

--- a/contracts/escrow/src/tests_e2e.rs
+++ b/contracts/escrow/src/tests_e2e.rs
@@ -698,3 +698,224 @@ fn test_e2e_event_sequence_full_lifecycle() {
     assert_eq!(ev_completed_id, match_id);
     assert_eq!(ev_winner, Winner::Player1);
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1123 — E2E: override_result then finalize_result payout path
+// ---------------------------------------------------------------------------
+//
+// Scenario:
+//   1. Oracle submits Player1 wins → match enters PendingResult.
+//   2. Admin calls override_result to change the winner to Player2.
+//   3. Advance ledger past DISPUTE_WINDOW_LEDGERS (17 280).
+//   4. Anyone calls finalize_result → payout executes.
+//   5. Assert Player2 receives the full pot; Player1 receives nothing extra.
+
+/// E2E test: oracle submits Player1 wins, admin overrides to Player2 wins,
+/// dispute window expires, finalize executes the overridden payout to Player2.
+#[test]
+fn test_e2e_override_result_then_finalize_payout_to_player2() {
+    let (env, contract_id, oracle, player1, player2, token, admin) = setup_e2e();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+
+    let stake: i128 = 200;
+    let game_id = String::from_str(&env, "e2e-override-finalize");
+
+    // ── Step 1: Create and fund the match ────────────────────────────────────
+    let match_id = client.create_match(
+        &player1,
+        &player2,
+        &stake,
+        &token,
+        &game_id,
+        &Platform::Lichess,
+    );
+    client.deposit(&match_id, &player1);
+    client.deposit(&match_id, &player2);
+
+    assert_eq!(client.get_match(&match_id).state, MatchState::Active);
+    assert_eq!(client.get_escrow_balance(&match_id), stake * 2);
+
+    // Snapshot balances after both deposits (each player deposited `stake`)
+    let p1_after_deposit = token_client.balance(&player1);
+    let p2_after_deposit = token_client.balance(&player2);
+
+    // ── Step 2: Oracle submits Player1 wins ─────────────────────────────────
+    client.submit_result(&match_id, &game_id, &Winner::Player1, &oracle);
+
+    let m = client.get_match(&match_id);
+    assert_eq!(m.state, MatchState::PendingResult);
+    assert_eq!(m.pending_winner, OptionalWinner::Some(Winner::Player1));
+
+    // Balances must be unchanged — no payout yet
+    assert_eq!(token_client.balance(&player1), p1_after_deposit);
+    assert_eq!(token_client.balance(&player2), p2_after_deposit);
+
+    // ── Step 3: Admin overrides to Player2 wins ─────────────────────────────
+    client.override_result(&match_id, &Winner::Player2, &admin);
+
+    let m = client.get_match(&match_id);
+    assert_eq!(m.state, MatchState::PendingResult, "state must remain PendingResult after override");
+    assert_eq!(
+        m.pending_winner,
+        OptionalWinner::Some(Winner::Player2),
+        "pending_winner must reflect the overridden result"
+    );
+
+    // Balances still unchanged — still within dispute window
+    assert_eq!(token_client.balance(&player1), p1_after_deposit);
+    assert_eq!(token_client.balance(&player2), p2_after_deposit);
+
+    // ── Step 4: Advance ledger past the dispute window ───────────────────────
+    // DISPUTE_WINDOW_LEDGERS = 17_280; advance by 17_281 to clear the boundary.
+    let current = env.ledger().sequence();
+    env.ledger().set_sequence_number(current + 17_281);
+
+    // ── Step 5: Finalize result — payout goes to Player2 ────────────────────
+    client.finalize_result(&match_id);
+
+    // ── Verify state ─────────────────────────────────────────────────────────
+    let m = client.get_match(&match_id);
+    assert_eq!(m.state, MatchState::Completed, "match must be Completed after finalize");
+
+    // Player2 receives the full pot (2 × stake); Player1 receives nothing
+    assert_eq!(
+        token_client.balance(&player2),
+        p2_after_deposit + stake * 2,
+        "Player2 must receive the full pot after the overridden finalize"
+    );
+    assert_eq!(
+        token_client.balance(&player1),
+        p1_after_deposit,
+        "Player1 must receive nothing after losing the override"
+    );
+
+    // Escrow must be empty
+    assert_eq!(client.get_escrow_balance(&match_id), 0);
+
+    // ── Verify completed event carries the overridden winner ─────────────────
+    let events = env.events().all();
+    let completed_topics = vec![
+        &env,
+        Symbol::new(&env, "match").into_val(&env),
+        soroban_sdk::symbol_short!("completed").into_val(&env),
+    ];
+    let (_, _, data) = events
+        .iter()
+        .find(|(_, t, _)| *t == completed_topics)
+        .expect("completed event must be emitted by finalize_result");
+    let (ev_id, ev_winner, ev_payout): (u64, Winner, i128) =
+        TryFromVal::try_from_val(&env, &data).unwrap();
+    assert_eq!(ev_id, match_id);
+    assert_eq!(ev_winner, Winner::Player2, "event winner must be the overridden value");
+    assert_eq!(ev_payout, stake * 2);
+}
+
+/// E2E test: oracle submits Draw, admin overrides to Player1 wins,
+/// finalize pays Player1 the full pot.
+#[test]
+fn test_e2e_override_draw_to_player1_wins() {
+    let (env, contract_id, oracle, player1, player2, token, admin) = setup_e2e();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+
+    let stake: i128 = 150;
+    let game_id = String::from_str(&env, "e2e-override-draw-p1");
+
+    let match_id = client.create_match(
+        &player1,
+        &player2,
+        &stake,
+        &token,
+        &game_id,
+        &Platform::ChessDotCom,
+    );
+    client.deposit(&match_id, &player1);
+    client.deposit(&match_id, &player2);
+
+    // Oracle submits Draw
+    client.submit_result(&match_id, &game_id, &Winner::Draw, &oracle);
+    assert_eq!(client.get_match(&match_id).pending_winner, OptionalWinner::Some(Winner::Draw));
+
+    // Admin overrides to Player1
+    client.override_result(&match_id, &Winner::Player1, &admin);
+    assert_eq!(
+        client.get_match(&match_id).pending_winner,
+        OptionalWinner::Some(Winner::Player1)
+    );
+
+    // Advance past dispute window and finalize
+    let current = env.ledger().sequence();
+    env.ledger().set_sequence_number(current + 17_281);
+    client.finalize_result(&match_id);
+
+    assert_eq!(client.get_match(&match_id).state, MatchState::Completed);
+    // Player1 wins the full pot
+    assert_eq!(token_client.balance(&player1), 1_000 + stake); // net gain = stake
+    assert_eq!(token_client.balance(&player2), 1_000 - stake); // net loss = stake
+    assert_eq!(client.get_escrow_balance(&match_id), 0);
+}
+
+/// E2E test: verify that override_result is rejected once the dispute window
+/// has expired — callers must use finalize_result after the window closes.
+#[test]
+fn test_e2e_override_result_rejected_after_window_expires() {
+    let (env, contract_id, oracle, player1, player2, token, admin) = setup_e2e();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let game_id = String::from_str(&env, "e2e-override-expired");
+
+    let match_id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &game_id,
+        &Platform::Lichess,
+    );
+    client.deposit(&match_id, &player1);
+    client.deposit(&match_id, &player2);
+    client.submit_result(&match_id, &game_id, &Winner::Player1, &oracle);
+
+    // Advance past the dispute window
+    let current = env.ledger().sequence();
+    env.ledger().set_sequence_number(current + 17_281);
+
+    // override_result must now be rejected
+    assert_eq!(
+        client.try_override_result(&match_id, &Winner::Player2, &admin),
+        Err(Ok(Error::DisputeWindowActive)),
+        "override_result must fail after the dispute window has expired"
+    );
+}
+
+/// E2E test: finalize_result is rejected while the dispute window is still open.
+#[test]
+fn test_e2e_finalize_result_rejected_during_dispute_window() {
+    let (env, contract_id, oracle, player1, player2, token, _admin) = setup_e2e();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let game_id = String::from_str(&env, "e2e-finalize-window-open");
+
+    let match_id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &game_id,
+        &Platform::Lichess,
+    );
+    client.deposit(&match_id, &player1);
+    client.deposit(&match_id, &player2);
+    client.submit_result(&match_id, &game_id, &Winner::Player1, &oracle);
+
+    // Dispute window is still open — finalize must be rejected
+    assert_eq!(
+        client.try_finalize_result(&match_id),
+        Err(Ok(Error::DisputeWindowActive)),
+        "finalize_result must be rejected while the dispute window is open"
+    );
+
+    // Match must still be PendingResult
+    assert_eq!(client.get_match(&match_id).state, MatchState::PendingResult);
+}


### PR DESCRIPTION
#1122 — Property-based state machine tests (contracts/escrow/src/tests.rs)
- Add proptest 1.4.0 to escrow dev-dependencies
- Add proptest_state_machine sub-module with 5 property tests:
  * prop_completed_is_terminal: all mutating ops rejected after Completed, across all three Winner variants
  * prop_cancelled_is_terminal: all mutating ops rejected after Cancelled, with or without a prior deposit
  * prop_active_cancel_always_rejected: cancel_match on Active always returns InvalidState for both players
  * prop_submit_result_only_valid_from_active: submit_result on Pending always returns InvalidState regardless of deposit count
  * prop_no_operation_accepted_in_terminal_state: comprehensive sweep of all mutating entry-points against both terminal states

#1123 — E2E override_result + finalize_result payout path (tests_e2e.rs)
- test_e2e_override_result_then_finalize_payout_to_player2: oracle submits Player1 wins → admin overrides to Player2 → advance past dispute window → finalize_result → Player2 receives full pot; completed event carries the overridden winner
- test_e2e_override_draw_to_player1_wins: oracle submits Draw → admin overrides to Player1 → finalize → Player1 receives full pot
- test_e2e_override_result_rejected_after_window_expires: override_result after window expiry returns DisputeWindowActive
- test_e2e_finalize_result_rejected_during_dispute_window: finalize_result during open window returns DisputeWindowActive

#1124 — Explicit AlreadyFunded test for player2 (tests.rs)
- Add test_second_deposit_player2_returns_already_funded: calls deposit twice for player2 and asserts the second call returns Err(Error::AlreadyFunded), documenting idempotency symmetrically for both players

#1125 — Cancelled state UI tests (MatchStatus.tsx + MatchStatus.test.tsx)
- Extend MatchData interface with cancelledBy, cancellationReason, player1Deposited, player2Deposited optional fields
- Update Cancelled branch in renderStateContent to render:
  * cancel-reason-player / cancel-reason-timeout with appropriate message
  * refund-info with per-player refund line items (refund-player1/refund-player2)
  * no-refund-info when no deposits were made
- Add 8 new Cancelled-state tests covering both cancellation paths and all refund display combinations (all 15 MatchStatus tests pass)

## Description

<!-- Provide a clear and concise description of the changes in this PR. What
     problem does it solve? What is the expected behaviour after merge? -->

## Type of Change

<!-- Check the category that best describes this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## Testing

<!-- Describe the testing you performed to verify your changes. Include steps
     to reproduce, test commands, and any relevant output. -->

- [ ] Tests added or updated
- [ ] Manual testing performed

## Contract Changes

<!-- If this PR changes smart contracts (contracts/), complete this section. -->

- [ ] ABI breaking? (requires re-deployment of existing contracts)
- [ ] Storage migration needed?
- [ ] ABI reviewed for breaking changes

## Security

<!-- Highlight any security-relevant considerations. -->

- [ ] No secrets committed
- [ ] Security implications considered and documented

## Documentation

- [ ] Relevant docs updated (docs/ folder, README, etc.)
Closes #1122 
Closes #1123 
Closes #1124 
Closes #1125 