### PR TITLE
fixed issues

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -166,7 +166,13 @@ impl EscrowContract {
         Ok(())
     }
 
-    /// Initialize the contract with a trusted oracle address, an admin, and a default token.
+    /// Initialize the contract with a trusted oracle address, an admin, a default token,
+    /// and a pre-registered safe address that is the sole permitted destination for
+    /// [`emergency_drain`](EscrowContract::emergency_drain).
+    ///
+    /// The `safe_address` is stored immutably at initialization time. It cannot be
+    /// changed afterwards. This eliminates the rug-pull vector where a compromised or
+    /// malicious admin could call `emergency_drain` with an arbitrary destination address.
     ///
     /// # Panics
     ///
@@ -176,6 +182,7 @@ impl EscrowContract {
         oracle: Address,
         admin: Address,
         token: Address,
+        safe_address: Address,
     ) -> Result<(), Error> {
         if env.storage().instance().has(&DataKey::Oracle) {
             panic!("Contract already initialized");
@@ -185,6 +192,9 @@ impl EscrowContract {
         env.storage().instance().set(&DataKey::Oracle, &oracle);
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Token, &token);
+        env.storage()
+            .instance()
+            .set(&DataKey::SafeAddress, &safe_address);
         env.storage().instance().set(&DataKey::MatchCount, &0u64);
         env.storage().instance().set(&DataKey::Paused, &false);
         env.storage()
@@ -845,8 +855,21 @@ impl EscrowContract {
         Ok(())
     }
 
-    /// Drain all token holdings to a safe address — admin only, requires contract to be paused.
-    pub fn emergency_drain(env: Env, to: Address, caller: Address) -> Result<(), Error> {
+    /// Drain all token holdings to the pre-registered safe address — admin only,
+    /// requires contract to be paused.
+    ///
+    /// The destination is fixed at initialization time via the `safe_address`
+    /// parameter of [`initialize`](EscrowContract::initialize) and stored under
+    /// [`DataKey::SafeAddress`]. The `to` parameter has been intentionally removed:
+    /// accepting an arbitrary destination address would allow a compromised or
+    /// malicious admin to redirect the drain to any address, constituting a
+    /// rug-pull vector against all players with funds in escrow.
+    ///
+    /// # Errors
+    ///
+    /// * [`Error::Unauthorized`] — `caller` is not the admin.
+    /// * [`Error::NotPaused`]    — the contract is not currently paused.
+    pub fn emergency_drain(env: Env, caller: Address) -> Result<(), Error> {
         let admin: Address = env
             .storage()
             .instance()
@@ -862,6 +885,12 @@ impl EscrowContract {
             return Err(Error::NotPaused);
         }
 
+        let safe_address: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::SafeAddress)
+            .ok_or(Error::Unauthorized)?;
+
         let token: Address = env
             .storage()
             .instance()
@@ -873,12 +902,12 @@ impl EscrowContract {
         let balance = client.balance(&contract);
 
         if balance > 0 {
-            client.transfer(&contract, &to, &balance);
+            client.transfer(&contract, &safe_address, &balance);
         }
 
         env.events().publish(
             (Symbol::new(&env, "admin"), symbol_short!("drain")),
-            (balance, to, admin),
+            (balance, safe_address, admin),
         );
 
         Ok(())

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -12,7 +12,7 @@ use soroban_sdk::{
     vec, Address, Env, IntoVal, String, Symbol, TryFromVal,
 };
 
-fn setup() -> (Env, Address, Address, Address, Address, Address, Address) {
+fn setup() -> (Env, Address, Address, Address, Address, Address, Address, Address) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -20,6 +20,7 @@ fn setup() -> (Env, Address, Address, Address, Address, Address, Address) {
     let oracle = Address::generate(&env);
     let player1 = Address::generate(&env);
     let player2 = Address::generate(&env);
+    let safe_address = Address::generate(&env);
 
     let token_id = env.register_stellar_asset_contract_v2(admin.clone());
     let token_addr = token_id.address();
@@ -29,7 +30,7 @@ fn setup() -> (Env, Address, Address, Address, Address, Address, Address) {
 
     let contract_id = env.register(EscrowContract, ());
     let client = EscrowContractClient::new(&env, &contract_id);
-    client.initialize(&oracle, &admin, &token_addr);
+    client.initialize(&oracle, &admin, &token_addr, &safe_address);
 
     // Fund the contract with the required reserve buffer.
     // `ensure_reserve_for_payout` requires the post-payout balance to stay
@@ -52,12 +53,13 @@ fn setup() -> (Env, Address, Address, Address, Address, Address, Address) {
         player2,
         token_addr,
         admin,
+        safe_address,
     )
 }
 
 #[test]
 fn test_create_match() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -87,7 +89,7 @@ fn test_get_match_not_found() {
 
 #[test]
 fn test_deposit_invalid_match_id_u64_max() {
-    let (env, contract_id, _oracle, player1, _player2, _token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, _player2, _token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     assert_eq!(
         client.try_deposit(&u64::MAX, &player1),
@@ -97,7 +99,7 @@ fn test_deposit_invalid_match_id_u64_max() {
 
 #[test]
 fn test_deposit_invalid_match_id_beyond_count() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     // Create one match (id = 0), then try to deposit into match 1 which doesn't exist
     client.create_match(
@@ -116,7 +118,7 @@ fn test_deposit_invalid_match_id_beyond_count() {
 
 #[test]
 fn test_cancel_match_invalid_match_id_u64_max() {
-    let (env, contract_id, _oracle, player1, _player2, _token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, _player2, _token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     assert_eq!(
         client.try_cancel_match(&u64::MAX, &player1),
@@ -126,7 +128,7 @@ fn test_cancel_match_invalid_match_id_u64_max() {
 
 #[test]
 fn test_cancel_match_invalid_match_id_beyond_count() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     client.create_match(
         &player1,
@@ -144,7 +146,7 @@ fn test_cancel_match_invalid_match_id_beyond_count() {
 
 #[test]
 fn test_submit_result_invalid_match_id_u64_max() {
-    let (env, contract_id, oracle, _player1, _player2, _token, _admin) = setup();
+    let (env, contract_id, oracle, _player1, _player2, _token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     assert_eq!(
         client.try_submit_result(
@@ -159,7 +161,7 @@ fn test_submit_result_invalid_match_id_u64_max() {
 
 #[test]
 fn test_submit_result_invalid_match_id_beyond_count() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     client.create_match(
         &player1,
@@ -192,7 +194,7 @@ fn test_get_match_invalid_match_id_u64_max() {
 
 #[test]
 fn test_get_match_invalid_match_id_beyond_count() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     client.create_match(
         &player1,
@@ -210,7 +212,7 @@ fn test_get_match_invalid_match_id_beyond_count() {
 
 #[test]
 fn test_deposit_and_activate() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -235,7 +237,7 @@ fn test_deposit_and_activate() {
 
 #[test]
 fn test_payout_winner() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -264,7 +266,7 @@ fn test_payout_winner() {
 
 #[test]
 fn test_payout_winner_player2() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -293,7 +295,7 @@ fn test_payout_winner_player2() {
 
 #[test]
 fn test_draw_refund() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -320,7 +322,7 @@ fn test_draw_refund() {
 
 #[test]
 fn test_cancel_refunds_depositor() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -343,7 +345,7 @@ fn test_cancel_refunds_depositor() {
 
 #[test]
 fn test_player2_can_cancel_pending_match() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -384,7 +386,8 @@ fn test_cancel_with_both_deposits_requires_both_auth() {
 
     let contract_id = env.register(EscrowContract, ());
     let client = EscrowContractClient::new(&env, &contract_id);
-    client.initialize(&oracle, &admin, &token_addr);
+    let safe_address = Address::generate(&env);
+    client.initialize(&oracle, &admin, &token_addr, &safe_address);
 
     // Fund reserve buffer (matches setup() helper — see ensure_reserve_for_payout)
     asset_client.mint(&contract_id, &crate::ESCROW_RESERVE_BUFFER_STROOPS);
@@ -422,7 +425,7 @@ fn test_cancel_with_both_deposits_requires_both_auth() {
 
 #[test]
 fn test_cancel_active_match_fails() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -444,7 +447,7 @@ fn test_cancel_active_match_fails() {
 
 #[test]
 fn test_cancel_completed_match_fails() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -472,7 +475,7 @@ fn test_cancel_completed_match_fails() {
 
 #[test]
 fn test_deposit_into_completed_match_fails() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -500,7 +503,7 @@ fn test_deposit_into_completed_match_fails() {
 
 #[test]
 fn test_deposit_after_cancel_returns_match_cancelled() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -521,7 +524,7 @@ fn test_deposit_after_cancel_returns_match_cancelled() {
 
 #[test]
 fn test_non_oracle_cannot_submit_result() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -554,7 +557,7 @@ fn test_non_oracle_cannot_submit_result() {
 fn test_submit_result_random_caller_is_unauthorized() {
     use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
 
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -591,7 +594,7 @@ fn test_submit_result_random_caller_is_unauthorized() {
 // Issue #196: submit_result on a Pending match should return InvalidState
 #[test]
 fn test_submit_result_on_pending_match_fails() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -617,7 +620,7 @@ fn test_submit_result_on_pending_match_fails() {
 // InvalidState (no double-payout)
 #[test]
 fn test_submit_result_on_completed_match_fails() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -650,7 +653,7 @@ fn test_submit_result_on_completed_match_fails() {
 
 #[test]
 fn test_submit_result_wrong_game_id_fails() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -689,13 +692,14 @@ fn test_double_initialize_fails() {
         .address();
     let contract_id = env.register(EscrowContract, ());
     let client = EscrowContractClient::new(&env, &contract_id);
-    client.initialize(&oracle, &admin, &token_addr);
-    client.initialize(&oracle, &admin, &token_addr);
+    let safe_address = Address::generate(&env);
+    client.initialize(&oracle, &admin, &token_addr, &safe_address);
+    client.initialize(&oracle, &admin, &token_addr, &safe_address);
 }
 
 #[test]
 fn test_create_match_zero_stake_fails() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     assert_eq!(
         client.try_create_match(
@@ -712,7 +716,7 @@ fn test_create_match_zero_stake_fails() {
 
 #[test]
 fn test_create_match_self_match_fails() {
-    let (env, contract_id, _oracle, player1, _player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, _player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     assert_eq!(
         client.try_create_match(
@@ -729,7 +733,7 @@ fn test_create_match_self_match_fails() {
 
 #[test]
 fn test_duplicate_game_id_rejected() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let player3 = Address::generate(&env);
     let player4 = Address::generate(&env);
@@ -758,7 +762,7 @@ fn test_duplicate_game_id_rejected() {
 
 #[test]
 fn test_duplicate_game_id_fails() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let player3 = Address::generate(&env);
     let player4 = Address::generate(&env);
@@ -786,7 +790,7 @@ fn test_duplicate_game_id_fails() {
 
 #[test]
 fn test_create_match_empty_game_id_fails() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     assert_eq!(
         client.try_create_match(
@@ -803,7 +807,7 @@ fn test_create_match_empty_game_id_fails() {
 
 #[test]
 fn test_create_match_wrong_token_fails() {
-    let (env, contract_id, _oracle, player1, player2, _token, admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, _token, admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     // Register a different token contract
@@ -827,7 +831,7 @@ fn test_create_match_wrong_token_fails() {
 #[test]
 #[should_panic(expected = "Error(Contract, #4)")]
 fn test_unauthorized_player_cannot_cancel() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let id = client.create_match(
         &player1,
@@ -843,7 +847,7 @@ fn test_unauthorized_player_cannot_cancel() {
 // Issue #192: deposit by non-player address should return Unauthorized
 #[test]
 fn test_deposit_by_non_player_returns_unauthorized() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -864,7 +868,7 @@ fn test_deposit_by_non_player_returns_unauthorized() {
 // Issue #195: is_funded returns false after only one player deposits, true after both
 #[test]
 fn test_is_funded_false_after_one_deposit() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -884,7 +888,7 @@ fn test_is_funded_false_after_one_deposit() {
 // Issue #818: get_escrow_balance returns stake_amount after only one deposit
 #[test]
 fn test_escrow_balance_after_single_deposit() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -901,7 +905,7 @@ fn test_escrow_balance_after_single_deposit() {
 
 #[test]
 fn test_escrow_balance_stages() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -921,7 +925,7 @@ fn test_escrow_balance_stages() {
 
 #[test]
 fn test_draw_payout_exact_amounts() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -949,7 +953,7 @@ fn test_draw_payout_exact_amounts() {
 
 #[test]
 fn test_update_oracle() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let new_oracle = Address::generate(&env);
 
@@ -988,7 +992,7 @@ fn test_update_oracle() {
 
 #[test]
 fn test_pause_blocks_all_state_changing_operations() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     // Create a match to test deposit and cancel while paused.
@@ -1065,7 +1069,7 @@ fn test_pause_blocks_all_state_changing_operations() {
 
 #[test]
 fn test_non_admin_cannot_pause() {
-    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let non_admin = Address::generate(&env);
 
@@ -1085,7 +1089,7 @@ fn test_non_admin_cannot_pause() {
 
 #[test]
 fn test_non_admin_cannot_unpause() {
-    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let non_admin = Address::generate(&env);
 
@@ -1125,7 +1129,7 @@ fn test_is_paused_returns_true_after_pause() {
 
 #[test]
 fn test_pause_unpause_events() {
-    let (env, contract_id, _, _, _, _, admin) = setup();
+    let (env, contract_id, _, _, _, _, admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let expected_pause_ledger_sequence = env.ledger().sequence();
@@ -1169,7 +1173,7 @@ fn test_pause_unpause_events() {
 
 #[test]
 fn test_update_oracle_emits_old_new_and_admin() {
-    let (env, contract_id, oracle, _, _, _, admin) = setup();
+    let (env, contract_id, oracle, _, _, _, admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let new_oracle = Address::generate(&env);
 
@@ -1205,7 +1209,8 @@ fn test_non_admin_cannot_update_oracle() {
         .address();
     let contract_id = env.register(EscrowContract, ());
     let client = EscrowContractClient::new(&env, &contract_id);
-    client.initialize(&oracle, &admin, &token_addr);
+    let safe_address = Address::generate(&env);
+    client.initialize(&oracle, &admin, &token_addr, &safe_address);
 
     use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
     env.mock_auths(&[MockAuth {
@@ -1223,7 +1228,7 @@ fn test_non_admin_cannot_update_oracle() {
 
 #[test]
 fn test_game_id_ttl_set_on_creation() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let game_id = String::from_str(&env, "ttl_game_id");
@@ -1246,7 +1251,7 @@ fn test_game_id_ttl_set_on_creation() {
 
 #[test]
 fn test_ttl_extended_on_state_changes() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -1280,7 +1285,7 @@ fn test_ttl_extended_on_state_changes() {
 
 #[test]
 fn test_create_match_emits_event() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let game_id = String::from_str(&env, "game_ev");
@@ -1314,7 +1319,7 @@ fn test_create_match_emits_event() {
 
 #[test]
 fn test_deposit_emits_event() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -1350,7 +1355,7 @@ fn test_deposit_emits_event() {
 
 #[test]
 fn test_deposit_event_player_label() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -1395,7 +1400,7 @@ fn test_deposit_event_player_label() {
 
 #[test]
 fn test_submit_result_emits_event() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -1434,7 +1439,7 @@ fn test_submit_result_emits_event() {
 
 #[test]
 fn test_cancel_match_emits_event() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -1465,7 +1470,7 @@ fn test_cancel_match_emits_event() {
 // Issue #59: Test that pause() prevents match creation
 #[test]
 fn test_pause_prevents_match_creation() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     client.pause();
@@ -1486,7 +1491,7 @@ fn test_pause_prevents_match_creation() {
 // Issue #60: Test that unpause() re-enables match creation
 #[test]
 fn test_unpause_enables_match_creation() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     client.pause();
@@ -1509,7 +1514,7 @@ fn test_unpause_enables_match_creation() {
 // Issue #61: Test that update_oracle() successfully rotates the oracle address
 #[test]
 fn test_update_oracle_rotates_address() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let new_oracle = Address::generate(&env);
 
@@ -1548,7 +1553,8 @@ fn test_non_admin_cannot_call_admin_functions() {
         .address();
     let contract_id = env.register(EscrowContract, ());
     let client = EscrowContractClient::new(&env, &contract_id);
-    client.initialize(&oracle, &admin, &token_addr);
+    let safe_address = Address::generate(&env);
+    client.initialize(&oracle, &admin, &token_addr, &safe_address);
 
     use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
 
@@ -1589,7 +1595,7 @@ fn test_non_admin_cannot_call_admin_functions() {
 // Issue #55: Multiple matches can be created and tracked independently
 #[test]
 fn test_multiple_matches_independent() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -1668,7 +1674,7 @@ fn test_multiple_matches_independent() {
 // Issue #56: Paused contract blocks deposit as well
 #[test]
 fn test_pause_blocks_deposit() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -1716,7 +1722,7 @@ fn test_pause_blocks_deposit() {
 // Issue #72: submit_result on already Cancelled match should return InvalidState
 #[test]
 fn test_submit_result_on_cancelled_match_fails() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -1748,7 +1754,7 @@ fn test_submit_result_on_cancelled_match_fails() {
 // guarantee is visible for both participants.
 #[test]
 fn test_second_deposit_player2_returns_already_funded() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -1773,7 +1779,7 @@ fn test_second_deposit_player2_returns_already_funded() {
 // Issue #33: Already-deposited player cannot deposit again
 #[test]
 fn test_double_deposit_same_player_fails() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -1794,7 +1800,7 @@ fn test_double_deposit_same_player_fails() {
 // Issue #34: Negative stake_amount is rejected
 #[test]
 fn test_create_match_negative_stake_fails() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     assert_eq!(
         client.try_create_match(
@@ -1812,7 +1818,7 @@ fn test_create_match_negative_stake_fails() {
 // Issue #35: get_escrow_balance returns 0 after match is cancelled with partial deposit
 #[test]
 fn test_escrow_balance_zero_after_cancel() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -1837,7 +1843,7 @@ fn test_escrow_balance_zero_after_cancel() {
 // cancel after both have committed funds. The only valid exit is submit_result by the oracle.
 #[test]
 fn test_cancel_with_both_deposits_requires_auth() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -1871,7 +1877,7 @@ fn test_cancel_with_both_deposits_requires_auth() {
 // Issue #100: Test that submit_result on a cancelled match returns InvalidState (no deposit)
 #[test]
 fn test_submit_result_on_cancelled_match_no_deposit_fails() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id = client.create_match(
@@ -1898,7 +1904,7 @@ fn test_submit_result_on_cancelled_match_no_deposit_fails() {
 // Issue #225: MatchCount overflow returns Error::Overflow instead of wrapping
 #[test]
 fn test_match_count_overflow_returns_error() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     // Seed the counter at u64::MAX so the next increment would overflow
@@ -1924,7 +1930,7 @@ fn test_match_count_overflow_returns_error() {
 // Issue #209 / Closes #36: Player2 win payout sends full pot to player2
 #[test]
 fn test_player2_win_payout_full_pot() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -1967,7 +1973,7 @@ fn test_player2_win_payout_full_pot() {
 // player2 balance must remain unchanged and escrow must return to 0.
 #[test]
 fn test_cancel_match_refunds_only_player1_when_only_player1_deposited() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -2021,7 +2027,7 @@ fn test_cancel_match_refunds_only_player1_when_only_player1_deposited() {
 
 #[test]
 fn test_reentrancy_deposit_checks_effects_interactions() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -2052,7 +2058,7 @@ fn test_reentrancy_deposit_checks_effects_interactions() {
 
 #[test]
 fn test_reentrancy_submit_result_checks_effects_interactions() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -2107,7 +2113,8 @@ fn test_deposit_insufficient_allowance() {
 
     let contract_id = env.register(EscrowContract, ());
     let client = EscrowContractClient::new(&env, &contract_id);
-    client.initialize(&oracle, &admin, &token_addr);
+    let safe_address = Address::generate(&env);
+    client.initialize(&oracle, &admin, &token_addr, &safe_address);
 
     let id = client.create_match(
         &player1,
@@ -2128,7 +2135,7 @@ fn test_deposit_insufficient_allowance() {
 // Issue: deposit succeeds when allowance is exactly the stake amount
 #[test]
 fn test_deposit_succeeds_with_exact_allowance() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -2151,11 +2158,13 @@ fn test_deposit_succeeds_with_exact_allowance() {
     assert_eq!(client.get_escrow_balance(&id), 100);
 }
 
-// Issue #912: emergency_drain — success, unpaused guard, non-admin guard
+// Issue #1102: emergency_drain — success, unpaused guard, non-admin guard
+// The `to` parameter has been removed from emergency_drain; the destination is
+// always the `safe_address` registered at initialize time.
 
 #[test]
 fn test_emergency_drain_succeeds_when_paused() {
-    let (env, contract_id, _oracle, player1, player2, token, admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, admin, safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -2176,14 +2185,14 @@ fn test_emergency_drain_succeeds_when_paused() {
 
     client.pause();
 
-    let safe = Address::generate(&env);
-    client.emergency_drain(&safe, &admin);
+    // emergency_drain no longer accepts a destination — it always drains to safe_address
+    client.emergency_drain(&admin);
 
     // Capture events BEFORE any further contract calls that might clear them
     let events = env.events().all();
 
     assert_eq!(token_client.balance(&contract_id), 0);
-    assert_eq!(token_client.balance(&safe), total_expected);
+    assert_eq!(token_client.balance(&safe_address), total_expected);
 
     // Verify drain event
     let drain_event = events.iter().find(|(_, t, _)| {
@@ -2202,24 +2211,22 @@ fn test_emergency_drain_succeeds_when_paused() {
 
 #[test]
 fn test_emergency_drain_fails_when_not_paused() {
-    let (env, contract_id, _oracle, _player1, _player2, _token, admin) = setup();
+    let (env, contract_id, _oracle, _player1, _player2, _token, admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
-    let safe = Address::generate(&env);
     assert_eq!(
-        client.try_emergency_drain(&safe, &admin),
+        client.try_emergency_drain(&admin),
         Err(Ok(Error::NotPaused))
     );
 }
 
 #[test]
 fn test_emergency_drain_fails_for_non_admin() {
-    let (env, contract_id, _oracle, _player1, _player2, _token, _admin) = setup();
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     client.pause();
     let non_admin = Address::generate(&env);
-    let safe = Address::generate(&env);
     assert_eq!(
-        client.try_emergency_drain(&safe, &non_admin),
+        client.try_emergency_drain(&non_admin),
         Err(Ok(Error::Unauthorized))
     );
 }
@@ -2228,7 +2235,7 @@ fn test_emergency_drain_fails_for_non_admin() {
 fn test_create_match_valid_platforms_accepted() {
     // Both known Platform variants must be accepted by create_match.
     // This test verifies the platform validation guard does not reject valid values.
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let id1 = client.create_match(
@@ -2247,7 +2254,7 @@ fn test_create_match_valid_platforms_accepted() {
 // Issue #794: get_oracle returns the address passed to initialize
 #[test]
 fn test_get_oracle_returns_initialized_address() {
-    let (env, contract_id, oracle, _player1, _player2, _token, _admin) = setup();
+    let (env, contract_id, oracle, _player1, _player2, _token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     assert_eq!(client.get_oracle(), oracle);
 }
@@ -2255,7 +2262,7 @@ fn test_get_oracle_returns_initialized_address() {
 // Issue #792: stake amount above MAX_STAKE is rejected
 #[test]
 fn test_create_match_stake_too_high_fails() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     assert_eq!(
         client.try_create_match(
@@ -2273,7 +2280,7 @@ fn test_create_match_stake_too_high_fails() {
 // Issue #791: stake amount below MIN_STAKE (e.g. zero) is rejected as StakeTooLow
 #[test]
 fn test_create_match_stake_below_min_fails() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
     assert_eq!(
         client.try_create_match(
@@ -2299,7 +2306,8 @@ fn test_instance_ttl_extended_on_initialize() {
     let token_addr = token_id.address();
     let contract_id = env.register(EscrowContract, ());
     let client = EscrowContractClient::new(&env, &contract_id);
-    client.initialize(&oracle, &admin, &token_addr);
+    let safe_address = Address::generate(&env);
+    client.initialize(&oracle, &admin, &token_addr, &safe_address);
 
     let instance_ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
     assert!(instance_ttl >= crate::INSTANCE_LIFETIME_THRESHOLD);
@@ -2351,7 +2359,8 @@ mod proptest_state_machine {
 
         let contract_id = env.register(EscrowContract, ());
         let client = EscrowContractClient::new(&env, &contract_id);
-        client.initialize(&oracle, &admin, &token_addr);
+        let safe_address = Address::generate(&env);
+        client.initialize(&oracle, &admin, &token_addr, &safe_address);
 
         let expiration = env.ledger().sequence() + 1_000_000;
         let token_client = TokenClient::new(&env, &token_addr);

--- a/contracts/escrow/src/tests_e2e.rs
+++ b/contracts/escrow/src/tests_e2e.rs
@@ -28,8 +28,8 @@ use soroban_sdk::{
 /// Spin up a fresh environment with two players, a token, and an initialised
 /// escrow contract.  Each player starts with 1 000 tokens.
 ///
-/// Returns `(env, contract_id, oracle, player1, player2, token_addr, admin)`.
-fn setup_e2e() -> (Env, Address, Address, Address, Address, Address, Address) {
+/// Returns `(env, contract_id, oracle, player1, player2, token_addr, admin, safe_address)`.
+fn setup_e2e() -> (Env, Address, Address, Address, Address, Address, Address, Address) {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -37,6 +37,7 @@ fn setup_e2e() -> (Env, Address, Address, Address, Address, Address, Address) {
     let oracle = Address::generate(&env);
     let player1 = Address::generate(&env);
     let player2 = Address::generate(&env);
+    let safe_address = Address::generate(&env);
 
     let token_id = env.register_stellar_asset_contract_v2(admin.clone());
     let token_addr = token_id.address();
@@ -46,7 +47,7 @@ fn setup_e2e() -> (Env, Address, Address, Address, Address, Address, Address) {
 
     let contract_id = env.register(EscrowContract, ());
     let client = EscrowContractClient::new(&env, &contract_id);
-    client.initialize(&oracle, &admin, &token_addr);
+    client.initialize(&oracle, &admin, &token_addr, &safe_address);
 
     // Approve the escrow contract for both players (needed for allowance check)
     let expiration = env.ledger().sequence() + 1000000;
@@ -62,6 +63,7 @@ fn setup_e2e() -> (Env, Address, Address, Address, Address, Address, Address) {
         player2,
         token_addr,
         admin,
+        safe_address,
     )
 }
 
@@ -73,7 +75,7 @@ fn setup_e2e() -> (Env, Address, Address, Address, Address, Address, Address) {
 /// Player1 wins -> verify balances, state, escrow balance, and events.
 #[test]
 fn test_e2e_lifecycle_player1_wins() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup_e2e();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup_e2e();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -165,7 +167,7 @@ fn test_e2e_lifecycle_player1_wins() {
 /// Same lifecycle but the oracle declares Player 2 the winner.
 #[test]
 fn test_e2e_lifecycle_player2_wins() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup_e2e();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup_e2e();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -228,7 +230,7 @@ fn test_e2e_lifecycle_player2_wins() {
 /// Same lifecycle but the oracle declares a draw; both players are refunded.
 #[test]
 fn test_e2e_lifecycle_draw() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup_e2e();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup_e2e();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -295,7 +297,7 @@ fn test_e2e_lifecycle_draw() {
 /// that each match payout is isolated.
 #[test]
 fn test_e2e_all_three_outcomes_sequential() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup_e2e();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup_e2e();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -390,7 +392,7 @@ fn test_e2e_all_three_outcomes_sequential() {
 /// `Unauthorized` even after both players have deposited.
 #[test]
 fn test_e2e_unauthorized_oracle_rejected() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup_e2e();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup_e2e();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let game_id = String::from_str(&env, "e2e-unauth-oracle");
@@ -424,7 +426,7 @@ fn test_e2e_unauthorized_oracle_rejected() {
 /// game_id must be rejected with `GameIdMismatch` and leave the match Active.
 #[test]
 fn test_e2e_game_id_mismatch_rejected() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup_e2e();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup_e2e();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let real_game_id = String::from_str(&env, "e2e-real-game");
@@ -458,7 +460,7 @@ fn test_e2e_game_id_mismatch_rejected() {
 /// return `InvalidState`.
 #[test]
 fn test_e2e_submit_result_on_pending_match_fails() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup_e2e();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup_e2e();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let game_id = String::from_str(&env, "e2e-pending-submit");
@@ -486,7 +488,7 @@ fn test_e2e_submit_result_on_pending_match_fails() {
 /// `InvalidState` -- no double-payout is possible.
 #[test]
 fn test_e2e_no_double_payout_after_completion() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup_e2e();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup_e2e();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -523,7 +525,7 @@ fn test_e2e_no_double_payout_after_completion() {
 /// Depositing into a Completed match must return `MatchCompleted`.
 #[test]
 fn test_e2e_deposit_into_completed_match_fails() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup_e2e();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup_e2e();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let game_id = String::from_str(&env, "e2e-dep-completed");
@@ -548,7 +550,7 @@ fn test_e2e_deposit_into_completed_match_fails() {
 /// Depositing into a Cancelled match must return `MatchCancelled`.
 #[test]
 fn test_e2e_deposit_into_cancelled_match_fails() {
-    let (env, contract_id, _oracle, player1, player2, token, _admin) = setup_e2e();
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup_e2e();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let match_id = client.create_match(
@@ -575,7 +577,7 @@ fn test_e2e_deposit_into_cancelled_match_fails() {
 /// 0 (created) -> stake (p1 deposited) -> 2xstake (p2 deposited) -> 0 (completed).
 #[test]
 fn test_e2e_escrow_balance_full_lifecycle() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup_e2e();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup_e2e();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let stake: i128 = 200;
@@ -615,7 +617,7 @@ fn test_e2e_escrow_balance_full_lifecycle() {
 /// each relevant call.
 #[test]
 fn test_e2e_event_sequence_full_lifecycle() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup_e2e();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup_e2e();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let game_id = String::from_str(&env, "e2e-event-seq");
@@ -714,7 +716,7 @@ fn test_e2e_event_sequence_full_lifecycle() {
 /// dispute window expires, finalize executes the overridden payout to Player2.
 #[test]
 fn test_e2e_override_result_then_finalize_payout_to_player2() {
-    let (env, contract_id, oracle, player1, player2, token, admin) = setup_e2e();
+    let (env, contract_id, oracle, player1, player2, token, admin, _safe_address) = setup_e2e();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -815,7 +817,7 @@ fn test_e2e_override_result_then_finalize_payout_to_player2() {
 /// finalize pays Player1 the full pot.
 #[test]
 fn test_e2e_override_draw_to_player1_wins() {
-    let (env, contract_id, oracle, player1, player2, token, admin) = setup_e2e();
+    let (env, contract_id, oracle, player1, player2, token, admin, _safe_address) = setup_e2e();
     let client = EscrowContractClient::new(&env, &contract_id);
     let token_client = TokenClient::new(&env, &token);
 
@@ -860,7 +862,7 @@ fn test_e2e_override_draw_to_player1_wins() {
 /// has expired — callers must use finalize_result after the window closes.
 #[test]
 fn test_e2e_override_result_rejected_after_window_expires() {
-    let (env, contract_id, oracle, player1, player2, token, admin) = setup_e2e();
+    let (env, contract_id, oracle, player1, player2, token, admin, _safe_address) = setup_e2e();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let game_id = String::from_str(&env, "e2e-override-expired");
@@ -892,7 +894,7 @@ fn test_e2e_override_result_rejected_after_window_expires() {
 /// E2E test: finalize_result is rejected while the dispute window is still open.
 #[test]
 fn test_e2e_finalize_result_rejected_during_dispute_window() {
-    let (env, contract_id, oracle, player1, player2, token, _admin) = setup_e2e();
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup_e2e();
     let client = EscrowContractClient::new(&env, &contract_id);
 
     let game_id = String::from_str(&env, "e2e-finalize-window-open");

--- a/contracts/escrow/src/types.rs
+++ b/contracts/escrow/src/types.rs
@@ -279,15 +279,16 @@ pub struct Match {
 /// All contract state is accessed through these keys. The variants map to
 /// different storage tiers:
 ///
-/// | Key variant      | Storage tier | Description                                  |
-/// |------------------|--------------|----------------------------------------------|
-/// | `Match(u64)`     | Persistent   | Full [`Match`] record, keyed by match ID     |
-/// | `MatchCount`     | Instance     | Running counter used to assign match IDs     |
-/// | `Oracle`         | Instance     | Address of the trusted oracle contract       |
-/// | `Admin`          | Instance     | Address of the contract administrator        |
-/// | `Paused`         | Instance     | Boolean pause flag                           |
-/// | `Token`          | Instance     | Default SEP-41 token address                 |
-/// | `GameId(String)` | Persistent   | Deduplication index: game_id → match ID      |
+/// | Key variant        | Storage tier | Description                                  |
+/// |--------------------|--------------|----------------------------------------------|
+/// | `Match(u64)`       | Persistent   | Full [`Match`] record, keyed by match ID     |
+/// | `MatchCount`       | Instance     | Running counter used to assign match IDs     |
+/// | `Oracle`           | Instance     | Address of the trusted oracle contract       |
+/// | `Admin`            | Instance     | Address of the contract administrator        |
+/// | `Paused`           | Instance     | Boolean pause flag                           |
+/// | `Token`            | Instance     | Default SEP-41 token address                 |
+/// | `SafeAddress`      | Instance     | Pre-registered destination for emergency_drain |
+/// | `GameId(String)`   | Persistent   | Deduplication index: game_id → match ID      |
 ///
 /// Instance-tier keys share the contract's instance TTL. Persistent-tier keys
 /// have their own TTL extended to `MATCH_TTL_LEDGERS` on every write.
@@ -342,6 +343,15 @@ pub enum DataKey {
     /// per-match tokens are supported in future versions.
     /// Stored in **instance** storage.
     Token,
+
+    /// The pre-registered destination address for [`emergency_drain`](crate::EscrowContract::emergency_drain).
+    ///
+    /// Set immutably during [`initialize`](crate::EscrowContract::initialize).
+    /// `emergency_drain` always transfers funds to this address — it cannot
+    /// be overridden at call time. This eliminates the rug-pull vector where
+    /// a compromised admin key could redirect the drain to an arbitrary address.
+    /// Stored in **instance** storage.
+    SafeAddress,
 
     /// Deduplication index mapping a `game_id` string to its match ID.
     ///

--- a/docs/security.md
+++ b/docs/security.md
@@ -6,7 +6,7 @@
 |-------|------|----------------|
 | **Player 1 / Player 2** | Create matches, deposit stakes, cancel matches | Authenticated by Stellar keypair. Trusted for own key management. Not trusted to act honestly toward each other. |
 | **Oracle** | Submits verified game results from Lichess/Chess.com | Authenticated by oracle keypair. Trusted for accurate result reporting. Not trusted with custody of funds. |
-| **Admin** | Pause/unpause contract, rotate oracle address | Authenticated by admin keypair. Trusted for emergency operations. Not trusted to access escrowed funds. |
+| **Admin** | Pause/unpause contract, rotate oracle address, trigger emergency drain | Authenticated by admin keypair. Trusted for emergency operations. Cannot redirect escrowed funds to an arbitrary address — `emergency_drain` always transfers to the `safe_address` fixed at initialization time. |
 | **Lichess / Chess.com API** | External source of truth for game outcomes | Outside the Soroban runtime boundary. Trusted to return correct results (within the oracle's verification logic). |
 | **Stellar / Soroban runtime** | Executes contract code, enforces authorization | Fully trusted for correct execution, state isolation, and ledger security. |
 
@@ -45,6 +45,7 @@
 | Oracle submits duplicate result to double-payout | `submit_result` | **High** | State machine rejects `submit_result` when `state != Active`; `Completed` is terminal |
 | Attacker creates multiple matches with same game_id | `create_match` | Medium | `DataKey::GameId` tracked; duplicate game_id returns `DuplicateGameId` error |
 | Admin drains funds without pause precondition | `emergency_drain` | Medium | `NotPaused` error if contract is not paused; event emitted for transparency |
+| Admin (or compromised admin key) drains funds to an arbitrary address (rug-pull) | `emergency_drain` | **High** | **Mitigated (issue #1102).** The `to` parameter has been removed. `emergency_drain` now always transfers to the `safe_address` registered immutably at `initialize` time. A compromised or malicious admin cannot redirect the drain to an attacker-controlled address. |
 
 ### Repudiation
 
@@ -85,10 +86,10 @@
 |-------|-------------|-----------------|
 | Stellar network | Correct execution of Soroban contracts | — |
 | Oracle service | Accurate game result reporting | Custody of player funds |
-| Admin key | Pause/unpause, oracle rotation | Accessing escrowed funds |
+| Admin key | Pause/unpause, oracle rotation, emergency drain to pre-registered safe address | Redirecting escrowed funds to an arbitrary address (structurally prevented — `emergency_drain` destination is fixed at init time) |
 | Players | Their own key management | Each other |
 
-No single party can unilaterally steal funds. The escrow contract enforces all payout rules on-chain.
+No single party can unilaterally redirect escrowed funds to an arbitrary address. `emergency_drain` is constrained to a pre-registered `safe_address` fixed at deployment. All other payout rules are enforced on-chain by the state machine.
 
 ---
 
@@ -117,6 +118,7 @@ No single party can unilaterally steal funds. The escrow contract enforces all p
 | | 1. **Multi-sig**: The admin address SHOULD be a multi-sig contract (e.g., Stellar clawback or Soroban multi-sig) requiring M-of-N signatures. |
 | | 2. **Backup keys**: At minimum, a backup admin key should be held by a separate trusted party. |
 | | 3. **Timelock**: A future enhancement should add a timelock between `pause()` and `emergency_drain()`, giving players time to react. |
+| | 4. **Safe address binding**: Even if the admin key is compromised (rather than lost), `emergency_drain` can only transfer to the `safe_address` fixed at `initialize` time — the attacker cannot redirect funds to an arbitrary address. |
 | **Recovery** | | |
 | | 1. If the contract has been initialized with a multi-sig admin, the admin role can be recovered through the multi-sig's governance process. |
 | | 2. **No on-chain recovery exists for a single-key admin**. The contract would need to be re-deployed and all active matches migrated off-chain. |
@@ -146,6 +148,27 @@ No single party can unilaterally steal funds. The escrow contract enforces all p
 ---
 
 ## Threat Model & Mitigations (per-function)
+
+### emergency_drain Rug-Pull (issue #1102)
+
+**Threat**: The original `emergency_drain(to: Address, caller: Address)` accepted an arbitrary destination address. A compromised or malicious admin could pause the contract and call `emergency_drain` with an attacker-controlled address as `to`, transferring the entire token balance — including all live player stakes — to that address. This is a classic rug-pull vector: a single compromised key grants unconditional custody over all escrowed funds.
+
+**Risk rating**: **Critical**. The admin key is the sole gating condition. There is no time-lock, no second signer requirement, and no on-chain recourse once the transfer executes.
+
+**Mitigation (applied — issue #1102)**:
+
+The `to` parameter has been removed from `emergency_drain`. A `safe_address: Address` parameter is now required in `initialize()` and stored immutably under `DataKey::SafeAddress`. `emergency_drain` reads that stored address and always drains to it — the call site cannot supply a different destination.
+
+```
+initialize(oracle, admin, token, safe_address)  ← safe_address set once, never changed
+emergency_drain(caller)                         ← destination is always DataKey::SafeAddress
+```
+
+**Residual risk**: The admin can still trigger a drain to `safe_address` at will (subject to the `is_paused` guard). If `safe_address` was set to an attacker-controlled address at deployment time, the protection is void. Operators MUST verify `safe_address` in the deployment transaction before any player funds are deposited. A future enhancement should add a timelock between `pause()` and `emergency_drain()` so players have a window to react.
+
+**What this does not protect against**:
+- A malicious deployer who sets `safe_address` to their own address at initialization time. Deployment-time parameters must be audited.
+- Admin key compromise used to pause the contract indefinitely (freezing player funds). This is mitigated separately by advising multi-sig admin keys.
 
 ### Re-initialization Attack
 
@@ -269,7 +292,7 @@ The concrete mitigations that apply regardless are:
 | `cancel_match` | `player1` or `player2` (requires auth) |
 | `submit_result` | Registered oracle address only |
 | `pause` / `unpause` | Admin only |
-| `emergency_drain` | Admin only (contract must be paused) |
+| `emergency_drain` | Admin only (contract must be paused; funds always sent to pre-registered `safe_address`) |
 | `update_oracle` | Admin only |
 | `get_match` / `is_funded` / `get_escrow_balance` | Anyone (read-only) |
 
@@ -314,16 +337,18 @@ No re-entrancy vectors exist in this codebase. The Soroban execution model provi
 ## Future Security Enhancements
 
 - **Multi-sig oracle**: Require M-of-N oracle signatures to submit a result, preventing single-key compromise from authorizing fraudulent payouts.
-- **Timelocked emergency drain**: Add a delay between `pause()` and `emergency_drain()` so players can monitor and react.
+- **Timelocked emergency drain**: Add a delay between `pause()` and `emergency_drain()` so players can monitor and react before funds are moved. (The destination is already fixed to `safe_address` — this enhancement would add a reaction window on top of that.)
 - **Result dispute window**: Allow players to challenge a result within a defined window by providing cryptographic proof.
 - **Admin social recovery**: N-of-M guardian accounts could restore admin access in case of key loss.
 - **Auto-cancel timeout**: Automatically cancel matches that remain in `Active` beyond a reasonable ledger count.
+- ~~**Restrict emergency_drain destination to a safe address**~~: **Done (issue #1102).** `emergency_drain` no longer accepts a `to` parameter. The destination is fixed at `initialize` time via `safe_address`.
 
 ## Threat Model Review Log
 
 | Date | Reviewer | Sign-off |
 |------|----------|----------|
 | 2026-06-24 | Internal review | ✅ Approved — STRIDE analysis complete, all identified threats have documented mitigations or accepted risk. |
+| 2026-07-25 | Issue #1102 remediation | ✅ `emergency_drain` rug-pull vector resolved. Removed arbitrary `to` parameter; drain destination now fixed to `safe_address` at `initialize` time. STRIDE Tampering table, per-function analysis, Trust Assumptions, and Access Control Summary updated to reflect the change. |
 
 ## Secrets Management
 


### PR DESCRIPTION
closes #1102 
closes #1103 
closes #1088 
closes #1090 

Contract hardening (contracts/escrow/src/)
  
  types.rs — Added SafeAddress variant to DataKey with full doc
  comment explaining it is set once at init and read exclusively
  by emergency_drain.
  
  lib.rs — Two changes:
  
  - initialize() gains a safe_address: Address parameter and
  stores it under DataKey::SafeAddress.
  - emergency_drain(env, to, caller) → emergency_drain(env,
  caller). The to parameter is gone entirely. The function reads
  DataKey::SafeAddress from storage and always transfers there.
  A compromised admin key can no longer redirect the drain to an
  arbitrary address.
  
  tests.rs / tests_e2e.rs — All setup() / setup_e2e() helpers
  updated to generate and pass safe_address to initialize. All
  10 initialize call-sites and all 3 emergency_drain call-sites
  updated. The success test now asserts that safe_address (not
  an arbitrary local) received the funds.
  
  ──────────────────────────────────────────────────────────────
  
  Threat model (docs/security.md)
  
  - System Actors — Admin row reworded: "Cannot redirect
  escrowed funds to an arbitrary address — emergency_drain
  always transfers to the safe_address fixed at initialization
  time."
  - STRIDE Tampering — New High-risk row: "Admin drains funds to
  an arbitrary address (rug-pull)" with "Mitigated (issue
  #1102)" status.
  - Admin Key Loss — Added mitigation #4: safe address binding
  limits the blast radius of a compromised (not just lost) admin
  key.
  - Per-function threats — New dedicated emergency_drain
  rug-pull section documenting the original threat, the fix,
  residual risk, and deployment-time audit requirement.
  - Access Control Summary — emergency_drain row clarified to
  note the safe_address constraint.
  - Trust Assumptions — Admin row and closing statement updated.
  - Future Enhancements — Timelock still listed as open;
  safe_address restriction marked as done.
  - Review Log — New entry: 2026-07-25 / issue #1102.

