### PR TITLE
feat(escrow): add get_platform read

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -929,6 +929,17 @@ impl EscrowContract {
             .ok_or(Error::MatchNotFound)
     }
 
+    /// Read the platform of a match by ID.
+    pub fn get_platform(env: Env, match_id: u64) -> Result<Platform, Error> {
+        Self::validate_match_id(&env, match_id)?;
+        let m: Match = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Match(match_id))
+            .ok_or(Error::MatchNotFound)?;
+        Ok(m.platform)
+    }
+
     /// Check whether both players have deposited.
     pub fn is_funded(env: Env, match_id: u64) -> Result<bool, Error> {
         let m: Match = env

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -211,6 +211,68 @@ fn test_get_match_invalid_match_id_beyond_count() {
 }
 
 #[test]
+fn test_get_platform_invalid_match_id_u64_max() {
+    let (env, contract_id, ..) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    assert!(matches!(
+        client.try_get_platform(&u64::MAX),
+        Err(Ok(Error::MatchNotFound))
+    ));
+}
+
+#[test]
+fn test_get_platform_invalid_match_id_beyond_count() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "get_platform_beyond"),
+        &Platform::Lichess,
+    );
+    assert!(matches!(
+        client.try_get_platform(&1),
+        Err(Ok(Error::MatchNotFound))
+    ));
+}
+
+#[test]
+fn test_get_platform_lichess() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "lichess-platform"),
+        &Platform::Lichess,
+    );
+
+    assert_eq!(client.get_platform(&id), Platform::Lichess);
+}
+
+#[test]
+fn test_get_platform_chessdotcom() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "chessdotcom-platform"),
+        &Platform::ChessDotCom,
+    );
+
+    assert_eq!(client.get_platform(&id), Platform::ChessDotCom);
+}
+
+#[test]
 fn test_deposit_and_activate() {
     let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);


### PR DESCRIPTION
## Summary

Adds a lightweight `get_platform` getter that returns only the `platform` enum for a given `match_id` without deserializing the full `Match` struct. This is useful for lightweight oracle services that only need platform information.

## Changes

* **contracts/escrow/src/lib.rs** — Added `pub fn get_platform(env: Env, match_id: u64) -> Result<Platform, Error>` which validates the match ID and reads only the platform field from persistent storage.
* **contracts/escrow/src/tests.rs** — Added unit tests covering invalid IDs (`u64::MAX` and beyond count) and both platform variants (`Lichess` and `ChessDotCom`).

## Behavior

* Reuses existing `validate_match_id` to enforce bounds checking.
* Reads the `Match` record from persistent storage and returns `m.platform`.
* Returns `Error::MatchNotFound` for out-of-range or non-existent matches.

Closes #1037
Closes #1038
Closes #1039
Closes #1040