### PR TITLE
fix(escrow): validate game_id character set in create_match (#1029)

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -145,6 +145,29 @@ impl EscrowContract {
         Ok(())
     }
 
+    /// Validate that every byte of `game_id` belongs to the set `[A-Za-z0-9_-]`.
+    ///
+    /// This enforces printable ASCII and prevents null bytes, control characters,
+    /// whitespace, and non-ASCII sequences from entering persistent storage.
+    /// The allowed set mirrors the identifier format used by Lichess and Chess.com.
+    ///
+    /// The string is copied into a fixed 64-byte stack buffer — the same size as
+    /// `MAX_GAME_ID_LEN` — so no heap allocation is required inside the WASM guest.
+    fn is_valid_game_id(game_id: &soroban_sdk::String) -> bool {
+        let len = game_id.len() as usize;
+        // Safety: len is already validated to be in [1, MAX_GAME_ID_LEN].
+        let mut buf = [0u8; MAX_GAME_ID_LEN as usize];
+        game_id.copy_into_slice(&mut buf[..len]);
+        for i in 0..len {
+            let b = buf[i];
+            let ok = b.is_ascii_alphanumeric() || b == b'_' || b == b'-';
+            if !ok {
+                return false;
+            }
+        }
+        true
+    }
+
     /// Pre-flight check that the contract retains at least
     /// [`ESCROW_RESERVE_BUFFER_STROOPS`] of `token` **after** a total payout of
     /// `payout_total` is subtracted.
@@ -319,6 +342,14 @@ impl EscrowContract {
         }
         let game_id_len = game_id.len();
         if game_id_len == 0 || game_id_len > MAX_GAME_ID_LEN {
+            return Err(Error::InvalidGameId);
+        }
+        // Enforce printable ASCII: only [A-Za-z0-9_-] are accepted.
+        // This closes the gap where a caller could submit a game_id containing
+        // null bytes, control characters, or non-ASCII sequences that would
+        // match the length check but silently diverge from the platform API
+        // lookup key used by the oracle.
+        if !Self::is_valid_game_id(&game_id) {
             return Err(Error::InvalidGameId);
         }
         if env

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -867,8 +867,136 @@ fn test_create_match_empty_game_id_fails() {
     );
 }
 
+// ── #1029: game_id character-set validation ──────────────────────────────────
+
 #[test]
-fn test_create_match_wrong_token_fails() {
+fn test_create_match_valid_game_id_alphanum() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    // Pure alphanumeric — should succeed
+    assert!(client
+        .try_create_match(
+            &player1,
+            &player2,
+            &100,
+            &token,
+            &String::from_str(&env, "abc123XYZ"),
+            &Platform::Lichess,
+        )
+        .is_ok());
+}
+
+#[test]
+fn test_create_match_valid_game_id_with_hyphen_and_underscore() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    // Hyphens and underscores are permitted
+    assert!(client
+        .try_create_match(
+            &player1,
+            &player2,
+            &100,
+            &token,
+            &String::from_str(&env, "game-001_ranked"),
+            &Platform::Lichess,
+        )
+        .is_ok());
+}
+
+#[test]
+fn test_create_match_game_id_with_null_byte_rejected() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    // Null byte — must be rejected
+    let game_id = String::from_bytes(&env, &[b'a', b'b', 0x00, b'c']);
+    assert_eq!(
+        client.try_create_match(
+            &player1,
+            &player2,
+            &100,
+            &token,
+            &game_id,
+            &Platform::Lichess,
+        ),
+        Err(Ok(Error::InvalidGameId))
+    );
+}
+
+#[test]
+fn test_create_match_game_id_with_control_char_rejected() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    // Tab control character (0x09) — must be rejected
+    let game_id = String::from_bytes(&env, &[b'g', b'a', b'm', b'e', 0x09]);
+    assert_eq!(
+        client.try_create_match(
+            &player1,
+            &player2,
+            &100,
+            &token,
+            &game_id,
+            &Platform::Lichess,
+        ),
+        Err(Ok(Error::InvalidGameId))
+    );
+}
+
+#[test]
+fn test_create_match_game_id_with_space_rejected() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    // Space (0x20) — must be rejected
+    assert_eq!(
+        client.try_create_match(
+            &player1,
+            &player2,
+            &100,
+            &token,
+            &String::from_str(&env, "game id"),
+            &Platform::Lichess,
+        ),
+        Err(Ok(Error::InvalidGameId))
+    );
+}
+
+#[test]
+fn test_create_match_game_id_with_non_ascii_rejected() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    // High byte 0x80 — must be rejected
+    let game_id = String::from_bytes(&env, &[b'g', b'a', b'm', b'e', 0x80]);
+    assert_eq!(
+        client.try_create_match(
+            &player1,
+            &player2,
+            &100,
+            &token,
+            &game_id,
+            &Platform::Lichess,
+        ),
+        Err(Ok(Error::InvalidGameId))
+    );
+}
+
+#[test]
+fn test_create_match_game_id_with_dot_rejected() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    // Dot (.) is not in the allowed set
+    assert_eq!(
+        client.try_create_match(
+            &player1,
+            &player2,
+            &100,
+            &token,
+            &String::from_str(&env, "game.id"),
+            &Platform::Lichess,
+        ),
+        Err(Ok(Error::InvalidGameId))
+    );
+}
+
+
     let (env, contract_id, _oracle, player1, player2, _token, admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
 


### PR DESCRIPTION
Only [A-Za-z0-9_-] are accepted as valid game_id characters.

Previously the only validation was length (1–64 bytes). A caller could submit a game_id containing null bytes (0x00), control characters, spaces, or high-byte non-ASCII sequences that would pass the length check but silently diverge from the platform API lookup key the oracle uses — causing permanent match/result mismatches.

Implementation:
- Add private helper EscrowContract::is_valid_game_id(game_id: &String) -> bool
- Copies game_id into a fixed [u8; 64] stack buffer (no heap allocation in WASM)
- Checks every byte with b.is_ascii_alphanumeric() || b == b'_' || b == b'-'
- Called immediately after the length check in create_match; returns InvalidGameId on failure

Allowed set [A-Za-z0-9_-] covers all known Lichess and Chess.com game ID formats.

Tests added:
- test_create_match_valid_game_id_alphanum
- test_create_match_valid_game_id_with_hyphen_and_underscore
- test_create_match_game_id_with_null_byte_rejected
- test_create_match_game_id_with_control_char_rejected
- test_create_match_game_id_with_space_rejected
- test_create_match_game_id_with_non_ascii_rejected
- test_create_match_game_id_with_dot_rejected

## Description

<!-- Provide a clear and concise description of the changes in this PR. What
     problem does it solve? What is the expected behaviour after merge? -->

## Type of Change

<!-- Check the category that best describes this PR. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## Testing

<!-- Describe the testing you performed to verify your changes. Include steps
     to reproduce, test commands, and any relevant output. -->

- [ ] Tests added or updated
- [ ] Manual testing performed

## Contract Changes

<!-- If this PR changes smart contracts (contracts/), complete this section. -->

- [ ] ABI breaking? (requires re-deployment of existing contracts)
- [ ] Storage migration needed?
- [ ] ABI reviewed for breaking changes

## Security

<!-- Highlight any security-relevant considerations. -->

- [ ] No secrets committed
- [ ] Security implications considered and documented

## Documentation

- [ ] Relevant docs updated (docs/ folder, README, etc.)
Closes #1029 