### PR TITLE
Add escrow get_oracle and get_admin read accessors

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -926,6 +926,22 @@ impl EscrowContract {
             .get(&DataKey::GameId(game_id))
     }
 
+    /// Read the current oracle address configured for the contract.
+    pub fn get_oracle(env: Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Oracle)
+            .ok_or(Error::Unauthorized)
+    }
+
+    /// Read the current admin address configured for the contract.
+    pub fn get_admin(env: Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)
+    }
+
     /// Read a match by ID.
     pub fn get_match(env: Env, match_id: u64) -> Result<Match, Error> {
         Self::validate_match_id(&env, match_id)?;

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -671,18 +671,18 @@ impl EscrowContract {
 
         let client = token::Client::new(&env, &m.token);
 
-        let payout_amount: i128 = match winner {
+        let payout_amount: i128 = match &winner {
             Winner::Draw => m.stake_amount,
             _ => m.stake_amount * 2,
         };
 
-        let total_payout = match winner {
+        let total_payout = match &winner {
             Winner::Draw => payout_amount * 2,
             _ => payout_amount,
         };
         Self::ensure_reserve_for_payout(&env, &m.token, total_payout)?;
 
-        match winner.clone() {
+        match &winner {
             Winner::Player1 => {
                 client.transfer(&env.current_contract_address(), &m.player1, &payout_amount)
             }

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -2368,6 +2368,13 @@ fn test_get_oracle_returns_initialized_address() {
     assert_eq!(client.get_oracle(), oracle);
 }
 
+#[test]
+fn test_get_admin_returns_initialized_address() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    assert_eq!(client.get_admin(), admin);
+}
+
 // Issue #792: stake amount above MAX_STAKE is rejected
 #[test]
 fn test_create_match_stake_too_high_fails() {


### PR DESCRIPTION
Closes #1021 

- adds a regression test for escrow balance while a match is in PendingResult state
- verifies the contract still reports the full pot while funds remain locked during the dispute window"


---

Closes #1023

Add public contract methods for reading the currently configured oracle and admin addresses, plus regression coverage for admin lookup.

---

Closes #1024 

Updated the payout logic in `lib.rs` so the winner is matched once and reused by reference for both payout amount calculation and the transfer block. This removes the extra clone while preserving the same behavior.

Verification:

Checked the edited file for diagnostics: no errors found.

