### PR TITLE
fix: add escrow boundary tests and prevent redundant state transitions

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -275,6 +275,9 @@ impl EscrowContract {
             .get(&DataKey::Admin)
             .ok_or(Error::Unauthorized)?;
         admin.require_auth();
+        if Self::is_paused(env.clone()) {
+            return Ok(());
+        }
         env.storage().instance().set(&DataKey::Paused, &true);
         env.events().publish(
             (Symbol::new(&env, "admin"), symbol_short!("paused")),
@@ -291,6 +294,9 @@ impl EscrowContract {
             .get(&DataKey::Admin)
             .ok_or(Error::Unauthorized)?;
         admin.require_auth();
+        if !Self::is_paused(env.clone()) {
+            return Ok(());
+        }
         env.storage().instance().set(&DataKey::Paused, &false);
         env.events().publish(
             (Symbol::new(&env, "admin"), symbol_short!("unpaused")),
@@ -617,6 +623,9 @@ impl EscrowContract {
         }
 
         let old_winner = m.pending_winner.clone();
+        if old_winner == OptionalWinner::Some(new_winner.clone()) {
+            return Ok(());
+        }
         m.pending_winner = OptionalWinner::Some(new_winner.clone());
 
         env.storage()

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -2355,6 +2355,55 @@ fn test_create_match_stake_too_high_fails() {
     );
 }
 
+#[test]
+fn test_create_match_max_stake() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &crate::MAX_STAKE,
+        &token,
+        &String::from_str(&env, "max_stake"),
+        &Platform::Lichess,
+    );
+    let m = client.get_match(&id);
+    assert_eq!(m.stake_amount, crate::MAX_STAKE);
+}
+
+#[test]
+fn test_finalize_result_dispute_window_boundary() {
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "boundary_test"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+
+    client.submit_result(
+        &id,
+        &String::from_str(&env, "boundary_test"),
+        &Winner::Player1,
+        &oracle,
+    );
+
+    let m = client.get_match(&id);
+    // advance the ledger to exactly the boundary
+    env.ledger().set_sequence_number(m.pending_result_ledger + crate::DISPUTE_WINDOW_LEDGERS);
+
+    assert_eq!(
+        client.try_finalize_result(&id),
+        Err(Ok(Error::DisputeWindowActive))
+    );
+}
+
 // Issue #791: stake amount below MIN_STAKE (e.g. zero) is rejected as StakeTooLow
 #[test]
 fn test_create_match_stake_below_min_fails() {


### PR DESCRIPTION
## Description
This PR addresses several boundary edge cases and prevents redundant state transitions that were emitting noisy events and causing unnecessary storage writes in the escrow contract. 

All existing functionality, architecture, and authorization models are preserved, and all tests continue to pass.

### Changes Included
- **Boundary Tests**: Added missing boundary coverage in `tests.rs` for the `MAX_STAKE` boundary (verifying exact acceptance) and the `DISPUTE_WINDOW_LEDGERS` boundary (verifying exact rejection before expiry).
- **Duplicate Overrides**: The `override_result` function now returns early (`Ok(())`) if the requested winner is identical to the current `pending_winner`, preventing duplicate events and storage writes.
- **Redundant Pauses**: The `pause()` and `unpause()` functions now check the current pause state and return early if the contract is already in the requested state, eliminating duplicate state transitions and event logs.

## Related Issues
Closes #1025
Closes #1026
Closes #1027
Closes #1028
