### PR TITLE
fix: resolve #1077, #1078, #1079, #1080 — Frontend UX and security issues

### DIFF
--- a/apps/frontend/public/_headers
+++ b/apps/frontend/public/_headers
@@ -1,0 +1,20 @@
+# HTTP headers applied to every route served from this origin.
+# Netlify and any Netlify-compatible CDN (Cloudflare Pages, etc.) honour this file.
+# The Vite dev server picks up the equivalent config from vite.config.ts.
+#
+# Content Security Policy rationale:
+#   script-src 'self'         — no inline scripts, no eval; prevents XSS from
+#                               injecting scripts that could steal signed transactions
+#   connect-src               — restricts XHR/fetch to the same origin and known
+#                               Stellar RPC / Horizon endpoints
+#   object-src 'none'         — disables Flash / plugin embeds entirely
+#   frame-ancestors 'none'    — clickjacking protection
+#
+# When upgrading to a hash-based script-src, replace 'self' with the
+# SHA-256 hash(es) of each permitted script chunk produced by the Vite build:
+#   script-src 'sha256-<hash1>' 'sha256-<hash2>'
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://soroban-testnet.stellar.org https://soroban-mainnet.stellar.org https://horizon-testnet.stellar.org https://horizon.stellar.org; img-src 'self' data:; font-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin

--- a/apps/frontend/src/components/DepositStake.tsx
+++ b/apps/frontend/src/components/DepositStake.tsx
@@ -148,9 +148,11 @@ export function DepositStake({
   const isCheckingAllowance = allowanceStatus === 'checking';
   const needsApproval = allowanceStatus === 'insufficient';
 
-  // Deposit button is disabled when: loading match data, player already deposited,
-  // allowance is still being checked, or allowance is insufficient
-  const isDisabled = isLoading || hasDeposited(matchDetails) || isCheckingAllowance || needsApproval;
+  // Deposit button is disabled when: loading match data, tx already in flight,
+  // player already deposited, allowance is still being checked, or allowance is
+  // insufficient. The isPending guard is the critical one — without it the user
+  // can click twice and submit duplicate transactions.
+  const isDisabled = isLoading || isPending || hasDeposited(matchDetails) || isCheckingAllowance || needsApproval;
 
   // Loading state
   if (isLoading && !matchDetails) {

--- a/apps/frontend/src/components/MatchStatus.tsx
+++ b/apps/frontend/src/components/MatchStatus.tsx
@@ -128,21 +128,37 @@ export function MatchStatus({
     }
   }, [matchId, onFetchMatch]);
 
+  // Track latest match state in a ref so the polling interval can read it
+  // without being recreated on every data update.
+  const matchDataRef = React.useRef<MatchData | null>(null);
+  useEffect(() => {
+    matchDataRef.current = matchData;
+  }, [matchData]);
+
   useEffect(() => {
     if (!matchId) return;
 
-    // Initial fetch - set loading status first
+    // Initial fetch on mount / matchId change
     setFetchStatus('loading');
     fetchMatch();
 
-    // Only poll if not in a terminal state
-    if (matchData && TERMINAL_STATES.includes(matchData.state)) {
-      return; // Don't poll for terminal states
-    }
+    // Poll every 10 seconds; stop automatically when a terminal state is reached.
+    // The interval is intentionally NOT re-created when matchData changes — we
+    // read the latest value through matchDataRef inside the callback instead.
+    const interval = setInterval(() => {
+      if (
+        matchDataRef.current &&
+        TERMINAL_STATES.includes(matchDataRef.current.state)
+      ) {
+        clearInterval(interval);
+        return;
+      }
+      fetchMatch();
+    }, 10_000);
 
-    const interval = setInterval(fetchMatch, 5000);
     return () => clearInterval(interval);
-  }, [matchId, fetchMatch, matchData]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [matchId, fetchMatch]);
 
   // Tick every second while in PendingResult to keep the countdown live.
   // The ticker is intentionally separate from the polling interval so it can

--- a/apps/frontend/src/hooks/useWallet.ts
+++ b/apps/frontend/src/hooks/useWallet.ts
@@ -21,6 +21,9 @@ declare global {
 
 const EXPECTED_NETWORK = (import.meta.env.VITE_STELLAR_NETWORK as string | undefined) || 'testnet';
 
+/** localStorage key used to persist the user's connection preference. */
+const WALLET_CONNECTED_KEY = 'wallet_connected';
+
 export function useWallet() {
   const [state, setState] = useState<WalletState>('checking');
   const [publicKey, setPublicKey] = useState<string | null>(null);
@@ -57,8 +60,24 @@ export function useWallet() {
     }
   }, []);
 
+  // On mount: if the user previously connected, attempt silent auto-reconnect.
+  // We only try if Freighter reports it is still connected — this avoids
+  // popping an unexpected permission prompt on a fresh session.
   useEffect(() => {
-    checkConnection();
+    const stored = localStorage.getItem(WALLET_CONNECTED_KEY);
+    if (stored === 'true') {
+      // Attempt auto-reconnect; checkConnection will set state appropriately
+      // if Freighter is no longer connected or the extension isn't installed.
+      checkConnection();
+    } else {
+      // No stored preference — resolve immediately so the UI isn't stuck in
+      // 'checking' state.
+      if (!window.stellar) {
+        setState('notInstalled');
+      } else {
+        setState('disconnected');
+      }
+    }
   }, [checkConnection]);
 
   const connect = useCallback(async () => {
@@ -87,8 +106,12 @@ export function useWallet() {
       if (net.network !== EXPECTED_NETWORK) {
         setState('wrongNetwork');
         setError(`Wrong network: expected ${EXPECTED_NETWORK}, got ${net.network}`);
+        // Still persist the preference — user is connected, just on wrong network
+        localStorage.setItem(WALLET_CONNECTED_KEY, 'true');
       } else {
         setState('connected');
+        // Persist the successful connection so we can auto-reconnect next session
+        localStorage.setItem(WALLET_CONNECTED_KEY, 'true');
       }
     } catch (err) {
       setState('disconnected');
@@ -112,6 +135,8 @@ export function useWallet() {
     setPublicKey(null);
     setNetwork(null);
     setError(null);
+    // Clear the stored preference so we don't auto-reconnect next session
+    localStorage.removeItem(WALLET_CONNECTED_KEY);
   }, []);
 
   return { state, publicKey, network, expectedNetwork, connect, switchNetwork, disconnect, error };

--- a/apps/frontend/tests/DepositStake.test.tsx
+++ b/apps/frontend/tests/DepositStake.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DepositStake } from '../src/components/DepositStake';
 
@@ -56,6 +56,58 @@ describe('DepositStake — deposit button states', () => {
     await waitFor(() => {
       expect(screen.getByTestId('deposit-btn')).toBeInTheDocument();
     });
+  });
+
+  /**
+   * #1080 — Regression guard for double-submit race condition.
+   *
+   * While an in-flight deposit transaction is pending the button must be:
+   *   - disabled (cannot be clicked again)
+   *   - aria-busy="true" (accessible loading indicator)
+   *   - showing the "Depositing…" label
+   *
+   * We use a never-resolving promise to freeze the component in the pending
+   * state so we can assert all three properties synchronously.
+   */
+  it('disables the button and shows a loading indicator while a deposit is in flight', async () => {
+    // onDeposit never resolves — keeps the component in the 'pending' state
+    // for as long as we need to make assertions.
+    let resolveDeposit!: () => void;
+    const inFlightDeposit = new Promise<void>((resolve) => {
+      resolveDeposit = resolve;
+    });
+    const onDeposit = vi.fn().mockReturnValue(inFlightDeposit);
+
+    render(
+      <DepositStake
+        matchId="123"
+        playerAddress="GABCDEF123456"
+        contractId="test-contract"
+        onDeposit={onDeposit}
+      />,
+    );
+
+    // Wait for match details to load so the deposit button is enabled
+    const depositBtn = await screen.findByTestId('deposit-btn');
+    expect(depositBtn).not.toBeDisabled();
+
+    // Trigger the deposit — this sets status to 'pending' synchronously
+    fireEvent.click(depositBtn);
+
+    // The button must be disabled while the transaction is in flight
+    expect(depositBtn).toBeDisabled();
+
+    // aria-busy must be true so screen readers announce the loading state
+    expect(depositBtn).toHaveAttribute('aria-busy', 'true');
+
+    // The label must communicate the in-progress state to sighted users
+    expect(depositBtn).toHaveTextContent('Depositing…');
+
+    // Confirm onDeposit was only called once — no double-submit
+    expect(onDeposit).toHaveBeenCalledTimes(1);
+
+    // Clean up: let the promise resolve so the component can unmount cleanly
+    resolveDeposit();
   });
 });
 

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -2,11 +2,64 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 
+/**
+ * Content Security Policy for smile4money frontend.
+ *
+ * Directives:
+ *   default-src 'self'          — block anything not explicitly allowed
+ *   script-src  'self'          — only scripts from the same origin; no inline
+ *                                 scripts and no eval (prevents XSS from
+ *                                 injecting scripts that steal signed txs)
+ *   style-src   'self' 'unsafe-inline'
+ *                               — Tailwind CSS-in-JS inlines styles at runtime;
+ *                                 remove 'unsafe-inline' and add hashes here
+ *                                 once the project migrates to static CSS
+ *   connect-src 'self' https://soroban-testnet.stellar.org
+ *               https://soroban-mainnet.stellar.org
+ *               https://horizon-testnet.stellar.org
+ *               https://horizon.stellar.org
+ *                               — allow Stellar RPC / Horizon calls; no other
+ *                                 origins may receive XHR / fetch requests
+ *   img-src     'self' data:    — inline SVG favicons and og-image use data URIs
+ *   font-src    'self'          — no external font CDNs
+ *   object-src  'none'          — disable Flash / plugin embeds entirely
+ *   base-uri    'self'          — prevent <base> tag injection
+ *   frame-ancestors 'none'     — clickjacking protection
+ *   form-action 'self'          — forms may only post to same origin
+ */
+const CSP = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  [
+    "connect-src 'self'",
+    'https://soroban-testnet.stellar.org',
+    'https://soroban-mainnet.stellar.org',
+    'https://horizon-testnet.stellar.org',
+    'https://horizon.stellar.org',
+  ].join(' '),
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "frame-ancestors 'none'",
+  "form-action 'self'",
+].join('; ');
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),
+    },
+  },
+  server: {
+    headers: {
+      'Content-Security-Policy': CSP,
+      // Belt-and-suspenders headers that reinforce the CSP
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Resolves four issues in the frontend: two UX regressions, one security gap, and a testing gap that uncovered a real double-submit bug.

---

### #1077 — MatchStatus.tsx: poll every 10s, stop on terminal state

**Root cause:** The polling `useEffect` listed `matchData` in its dependency array. Every time `fetchMatch` resolved and called `setMatchData`, React re-ran the effect — clearing the old interval and immediately creating a new one. The terminal-state guard checked stale data and was effectively a no-op.

**Fix:** Removed `matchData` from the effect's deps. A `useRef` syncs the latest state value into a ref the interval reads directly, so the effect is only created once per `matchId` change. Interval changed from 5 s → 10 s per the issue spec.

---

### #1078 — Content Security Policy headers

No server or hosting config existed. CSP is now set in two places:

- `vite.config.ts` — `server.headers` block for the Vite dev server
- `public/_headers` — Netlify / Cloudflare Pages convention for static deployments

Policy summary:
```
default-src 'self'
script-src 'self'              ← no inline scripts, no eval
connect-src 'self' https://soroban-testnet.stellar.org https://soroban-mainnet.stellar.org ...
object-src 'none'
frame-ancestors 'none'         ← clickjacking protection
```

---

### #1079 — Wallet connection persisted to localStorage

Added `WALLET_CONNECTED_KEY = 'wallet_connected'` flag:

- **On mount:** if the flag is set, `checkConnection()` attempts a silent auto-reconnect using Freighter's `isConnected()` API (no permission prompt)
- **On connect:** flag is written on successful connection
- **On disconnect:** flag is removed so the next session starts clean

---

### #1080 — DepositStake: in-flight loading test + real bug fix

Added a test that uses a never-resolving promise to freeze the component in `status === 'pending'` and asserts:
- Button is `disabled`
- `aria-busy="true"` (accessible loading state)
- Label reads `"Depositing…"`
- `onDeposit` called exactly once (no double-submit)

The test **immediately caught a production bug**: `isPending` was missing from the `isDisabled` expression in `DepositStake.tsx`, meaning users could click the button multiple times mid-transaction. Fixed alongside the test.

---

## Test results

```
Test Files  12 passed | 1 skipped (13)
     Tests  123 passed | 1 skipped (124)
```

## Files changed

| File | Change |
|---|---|
| `apps/frontend/src/components/MatchStatus.tsx` | Fix polling (useRef, 10s, terminal-state stop) |
| `apps/frontend/vite.config.ts` | Add CSP + security headers to dev server |
| `apps/frontend/public/_headers` | Add CSP + security headers for static hosting |
| `apps/frontend/src/hooks/useWallet.ts` | localStorage auto-reconnect persistence |
| `apps/frontend/tests/DepositStake.test.tsx` | Add in-flight disabled/loading state test |
| `apps/frontend/src/components/DepositStake.tsx` | Fix: add `isPending` to `isDisabled` guard |

closes #1077 
closes #1078 
closes #1079 
closes #1080 