### PR TITLE
fix(escrow): resolve 4 issues — auth, perf, error clarity, mutual cancel

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -37,6 +37,7 @@ use soroban_sdk::contracterror;
 /// | 24   | StakeTooLow           | stake_amount is below the minimum allowed stake |
 /// | 25   | StakeTooHigh          | stake_amount exceeds the maximum allowed stake |
 /// | 26   | InsufficientReserve   | contract balance too low to cover payout + Stellar minimum reserve |
+/// | 27   | TimeoutNotReached     | claim_timeout called before the 7-day timeout period has elapsed |
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
@@ -129,4 +130,9 @@ pub enum Error {
     /// minimum account reserve after the payout. Top up the contract address with
     /// enough XLM (or configured token) to cover the 1.5 XLM reserve buffer, then retry.
     InsufficientReserve = 26,
+
+    /// [E027] `claim_timeout` was called before the 7-day timeout period
+    /// (`TIMEOUT_LEDGERS`) has elapsed since the match became `Active`. Wait
+    /// until the timeout period expires before calling `claim_timeout`.
+    TimeoutNotReached = 27,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -17,8 +17,9 @@
 //!                │               │
 //!                ▼               ▼
 //!            Cancelled        Active ──── claim_timeout() ──► Cancelled
-//!                           (funds held)
-//!                                │
+//!                           (funds held)         │
+//!                                │        cancel_match()
+//!                                │        (both players) ──► Cancelled
 //!                         submit_result()
 //!                          (oracle only)
 //!                                │
@@ -119,14 +120,13 @@ const TIMEOUT_LEDGERS: u32 = 120_960;
 const ESCROW_RESERVE_BUFFER_STROOPS: i128 = 15_000_000;
 
 fn is_zero_address(env: &Env, addr: &Address) -> bool {
-    let zero_address: Address = TryFromVal::try_from_val(
-        &env,
-        &String::from_str(
-            &env,
-            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
-        ),
-    )
-    .expect("invalid zero address constant");
+    // The all-zeros Stellar account key encodes to this strkey.
+    // We construct the Address via the ScAddress XDR path since
+    // TryFromVal<Env, String> is not implemented for Address.
+    use soroban_sdk::xdr::{AccountId, PublicKey, ScAddress, Uint256};
+    let zero_key = Uint256([0u8; 32]);
+    let sc_addr = ScAddress::Account(AccountId(PublicKey::PublicKeyTypeEd25519(zero_key)));
+    let zero_address = Address::try_from_val(env, &sc_addr).expect("invalid zero address");
     addr == &zero_address
 }
 
@@ -136,7 +136,7 @@ pub struct EscrowContract;
 #[contractimpl]
 impl EscrowContract {
     /// Return whether the contract is currently paused.
-    pub fn is_paused(env: Env) -> bool {
+    pub fn is_paused(env: &Env) -> bool {
         env.storage()
             .instance()
             .get(&DataKey::Paused)
@@ -311,7 +311,7 @@ impl EscrowContract {
     ) -> Result<u64, Error> {
         player1.require_auth();
 
-        if Self::is_paused(env.clone()) {
+        if Self::is_paused(&env) {
             return Err(Error::ContractPaused);
         }
         if stake_amount < MIN_STAKE {
@@ -405,7 +405,7 @@ impl EscrowContract {
     pub fn deposit(env: Env, match_id: u64, player: Address) -> Result<(), Error> {
         player.require_auth();
 
-        if Self::is_paused(env.clone()) {
+        if Self::is_paused(&env) {
             return Err(Error::ContractPaused);
         }
 
@@ -506,7 +506,7 @@ impl EscrowContract {
         winner: Winner,
         caller: Address,
     ) -> Result<(), Error> {
-        if Self::is_paused(env.clone()) {
+        if Self::is_paused(&env) {
             return Err(Error::ContractPaused);
         }
 
@@ -638,15 +638,22 @@ impl EscrowContract {
 
     /// Finalize a pending result and execute payout after the dispute window has expired.
     ///
-    /// Can be called by anyone once `DISPUTE_WINDOW_LEDGERS` have elapsed since the oracle
-    /// submitted the result. Executes the payout based on `pending_winner` and transitions
-    /// the match to `Completed`.
+    /// May only be called by one of the **matched players** (`player1` or `player2`),
+    /// the registered **oracle**, or the **admin**. This prevents a third party from
+    /// triggering payout transactions on behalf of players (e.g. to collect fee rebates
+    /// or grief a player who intended to call `finalize_result` themselves).
+    ///
+    /// # Arguments
+    ///
+    /// * `match_id` — The match to finalize.
+    /// * `caller`   — Must be `player1`, `player2`, the oracle, or the admin; must authorize.
     ///
     /// # Errors
     ///
+    /// * [`Error::Unauthorized`]        — caller is not a matched player, the oracle, or the admin.
     /// * [`Error::InvalidState`]        — match is not in `PendingResult` state.
     /// * [`Error::DisputeWindowActive`] — dispute window has not yet expired.
-    pub fn finalize_result(env: Env, match_id: u64) -> Result<(), Error> {
+    pub fn finalize_result(env: Env, match_id: u64, caller: Address) -> Result<(), Error> {
         Self::validate_match_id(&env, match_id)?;
 
         let mut m: Match = env
@@ -654,6 +661,25 @@ impl EscrowContract {
             .persistent()
             .get(&DataKey::Match(match_id))
             .ok_or(Error::MatchNotFound)?;
+
+        // Authorisation: only player1, player2, the oracle, or the admin may
+        // call finalize_result. This stops any random account from triggering
+        // the payout (e.g. to collect fee rebates or grief a player).
+        let oracle: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Oracle)
+            .ok_or(Error::Unauthorized)?;
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+
+        if caller != m.player1 && caller != m.player2 && caller != oracle && caller != admin {
+            return Err(Error::Unauthorized);
+        }
+        caller.require_auth();
 
         if m.state != MatchState::PendingResult {
             return Err(Error::InvalidState);
@@ -729,9 +755,10 @@ impl EscrowContract {
     ///
     /// # Errors
     ///
-    /// * [`Error::Unauthorized`]  — caller is neither player.
-    /// * [`Error::InvalidState`]  — match is not `Active`.
-    /// * [`Error::MatchTimedOut`] — not enough ledgers have passed yet (too early to claim).
+    /// * [`Error::Unauthorized`]       — caller is neither player.
+    /// * [`Error::InvalidState`]       — match is not `Active`.
+    /// * [`Error::TimeoutNotReached`]  — `TIMEOUT_LEDGERS` have not yet elapsed since the
+    ///                                   match became `Active`; it is too early to reclaim.
     pub fn claim_timeout(env: Env, match_id: u64, caller: Address) -> Result<(), Error> {
         caller.require_auth();
 
@@ -754,10 +781,8 @@ impl EscrowContract {
 
         let current = env.ledger().sequence();
         if current <= m.activated_ledger + TIMEOUT_LEDGERS {
-            // Timeout period has not elapsed yet — reject with MatchTimedOut reused
-            // as "too early". We return MatchTimedOut here to keep error codes minimal;
-            // callers should interpret it as "timeout not yet reached".
-            return Err(Error::MatchTimedOut);
+            // Timeout period has not elapsed yet — the match is still live.
+            return Err(Error::TimeoutNotReached);
         }
 
         let client = token::Client::new(&env, &m.token);
@@ -786,14 +811,16 @@ impl EscrowContract {
         Ok(())
     }
 
-    /// Cancel a pending match and refund any deposits.
+    /// Cancel a match and refund any deposits.
     ///
     /// Authorization model:
-    /// - If neither or only one player has deposited: the calling player's auth suffices.
-    /// - If both players have deposited: both players must authorize, because cancelling
-    ///   would withdraw funds that the other player has already committed.
+    /// - **Pending state** (neither or only one player deposited): the calling player's auth suffices.
+    /// - **Pending state** (both players deposited, rare edge case): both players must authorize.
+    /// - **Active state** (both players deposited, match is live): both `player1` and `player2`
+    ///   must authorize, enabling a mutual cancel without waiting for the 7-day
+    ///   `claim_timeout`. Both stakes are refunded immediately.
     ///
-    /// Cancelation is allowed while the contract is paused so players can recover funds.
+    /// Cancellation is allowed while the contract is paused so players can recover funds.
     pub fn cancel_match(env: Env, match_id: u64, caller: Address) -> Result<(), Error> {
         Self::validate_match_id(&env, match_id)?;
 
@@ -803,7 +830,9 @@ impl EscrowContract {
             .get(&DataKey::Match(match_id))
             .ok_or(Error::MatchNotFound)?;
 
-        if m.state != MatchState::Pending {
+        // Allow cancellation from Pending or Active state only.
+        // Completed and Cancelled are terminal — no further transitions.
+        if m.state != MatchState::Pending && m.state != MatchState::Active {
             return Err(Error::InvalidState);
         }
 
@@ -814,7 +843,14 @@ impl EscrowContract {
             return Err(Error::Unauthorized);
         }
 
-        if m.player1_deposited && m.player2_deposited {
+        if m.state == MatchState::Active {
+            // Active state: both players must mutually agree to cancel.
+            // Require authorization from both parties since both have already
+            // committed funds and neither should be able to unilaterally cancel.
+            m.player1.require_auth();
+            m.player2.require_auth();
+        } else if m.player1_deposited && m.player2_deposited {
+            // Pending state but both deposited (rare): same mutual-auth requirement.
             m.player1.require_auth();
             m.player2.require_auth();
         } else {
@@ -887,7 +923,7 @@ impl EscrowContract {
         }
         caller.require_auth();
 
-        if !Self::is_paused(env.clone()) {
+        if !Self::is_paused(&env) {
             return Err(Error::NotPaused);
         }
 

--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -7,6 +7,7 @@ use soroban_sdk::{
         storage::Persistent as _,
         Address as _,
         Events,
+        Ledger as _,
     },
     token::{Client as TokenClient, StellarAssetClient},
     vec, Address, Env, IntoVal, String, Symbol, TryFromVal,
@@ -486,25 +487,92 @@ fn test_cancel_with_both_deposits_requires_both_auth() {
 }
 
 #[test]
-fn test_cancel_active_match_fails() {
+fn test_cancel_active_match_unilateral_fails() {
+    use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
+
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let player1 = Address::generate(&env);
+    let player2 = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_addr = token_id.address();
+    let asset_client = StellarAssetClient::new(&env, &token_addr);
+
+    env.mock_all_auths();
+    asset_client.mint(&player1, &1000);
+    asset_client.mint(&player2, &1000);
+
+    let contract_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let safe_address = Address::generate(&env);
+    client.initialize(&oracle, &admin, &token_addr, &safe_address);
+    asset_client.mint(&contract_id, &crate::ESCROW_RESERVE_BUFFER_STROOPS);
+
+    let expiration = env.ledger().sequence() + 1000000;
+    let token_client = TokenClient::new(&env, &token_addr);
+    token_client.approve(&player1, &contract_id, &1000, &expiration);
+    token_client.approve(&player2, &contract_id, &1000, &expiration);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token_addr,
+        &String::from_str(&env, "active_cancel"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    assert_eq!(client.get_match(&id).state, MatchState::Active);
+
+    // Unilateral cancel (only player1 auth) must be rejected
+    env.mock_auths(&[MockAuth {
+        address: &player1,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "cancel_match",
+            args: (id, player1.clone()).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    assert!(
+        client.try_cancel_match(&id, &player1).is_err(),
+        "unilateral cancel by player1 must be rejected for Active match"
+    );
+
+    // Match must remain Active
+    env.mock_all_auths();
+    assert_eq!(client.get_match(&id).state, MatchState::Active);
+}
+
+#[test]
+fn test_cancel_active_match_mutual_succeeds() {
     let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
 
     let id = client.create_match(
         &player1,
         &player2,
         &100,
         &token,
-        &String::from_str(&env, "active_cancel"),
+        &String::from_str(&env, "active_mutual_cancel"),
         &Platform::Lichess,
     );
     client.deposit(&id, &player1);
     client.deposit(&id, &player2);
+    assert_eq!(client.get_match(&id).state, MatchState::Active);
 
-    assert_eq!(
-        client.try_cancel_match(&id, &player1),
-        Err(Ok(Error::InvalidState))
-    );
+    // Mutual cancel (mock_all_auths covers both) must succeed
+    client.cancel_match(&id, &player1);
+
+    assert_eq!(client.get_match(&id).state, MatchState::Cancelled);
+    // Both players refunded
+    assert_eq!(token_client.balance(&player1), 1000);
+    assert_eq!(token_client.balance(&player2), 1000);
+    assert_eq!(client.get_escrow_balance(&id), 0);
 }
 
 #[test]
@@ -1917,12 +1985,13 @@ fn test_escrow_balance_zero_after_cancel() {
 }
 
 // Issue #180: Once both players have deposited the match transitions to Active.
-// cancel_match must be rejected for Active matches — neither player can unilaterally
-// cancel after both have committed funds. The only valid exit is submit_result by the oracle.
+// Mutual cancel_match is now allowed for Active matches — both players must authorize.
+// Unilateral cancel (only one player's auth) must still be rejected.
 #[test]
 fn test_cancel_with_both_deposits_requires_auth() {
     let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
     let client = EscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
 
     let id = client.create_match(
         &player1,
@@ -1938,18 +2007,14 @@ fn test_cancel_with_both_deposits_requires_auth() {
     client.deposit(&id, &player2);
     assert_eq!(client.get_match(&id).state, MatchState::Active);
 
-    // Neither player can cancel once the match is Active
-    assert_eq!(
-        client.try_cancel_match(&id, &player1),
-        Err(Ok(Error::InvalidState))
-    );
-    assert_eq!(
-        client.try_cancel_match(&id, &player2),
-        Err(Ok(Error::InvalidState))
-    );
+    // With mock_all_auths, mutual cancel must succeed
+    client.cancel_match(&id, &player1);
 
-    // Match must remain Active — funds are safe
-    assert_eq!(client.get_match(&id).state, MatchState::Active);
+    assert_eq!(client.get_match(&id).state, MatchState::Cancelled);
+    // Both players are fully refunded
+    assert_eq!(token_client.balance(&player1), 1000);
+    assert_eq!(token_client.balance(&player2), 1000);
+    assert_eq!(client.get_escrow_balance(&id), 0);
 }
 
 // Issue #100: Test that submit_result on a cancelled match returns InvalidState (no deposit)
@@ -2391,9 +2456,307 @@ fn test_instance_ttl_extended_on_initialize() {
     assert!(instance_ttl >= crate::INSTANCE_LIFETIME_THRESHOLD);
 }
 
-// ═══════════════════════════════════════════════════════════════════════════
-// Issue #1122 — Property-based tests for state machine transition invariants
-// ═══════════════════════════════════════════════════════════════════════════
+// ── claim_timeout tests ───────────────────────────────────────────────────────
+
+/// claim_timeout called before the timeout period elapses must return
+/// Error::TimeoutNotReached (not MatchTimedOut — semantically correct error).
+#[test]
+fn test_claim_timeout_before_period_returns_timeout_not_reached() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "claim_too_early"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    assert_eq!(client.get_match(&id).state, MatchState::Active);
+
+    // Timeout period has NOT elapsed — must get TimeoutNotReached
+    assert_eq!(
+        client.try_claim_timeout(&id, &player1),
+        Err(Ok(Error::TimeoutNotReached)),
+        "claim_timeout too early must return TimeoutNotReached"
+    );
+}
+
+/// claim_timeout called after the timeout period elapses must succeed and refund both players.
+#[test]
+fn test_claim_timeout_after_period_succeeds() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "claim_after_timeout"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    assert_eq!(client.get_match(&id).state, MatchState::Active);
+
+    // Advance ledger past TIMEOUT_LEDGERS (120_960)
+    let current = env.ledger().sequence();
+    env.ledger().set_sequence_number(current + crate::TIMEOUT_LEDGERS + 1);
+
+    client.claim_timeout(&id, &player1);
+
+    assert_eq!(client.get_match(&id).state, MatchState::Cancelled);
+    // Both players fully refunded
+    assert_eq!(token_client.balance(&player1), 1000);
+    assert_eq!(token_client.balance(&player2), 1000);
+    assert_eq!(client.get_escrow_balance(&id), 0);
+}
+
+/// claim_timeout by a non-player must return Unauthorized.
+#[test]
+fn test_claim_timeout_by_non_player_fails() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "claim_non_player"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+
+    let current = env.ledger().sequence();
+    env.ledger().set_sequence_number(current + crate::TIMEOUT_LEDGERS + 1);
+
+    let stranger = Address::generate(&env);
+    assert_eq!(
+        client.try_claim_timeout(&id, &stranger),
+        Err(Ok(Error::Unauthorized))
+    );
+}
+
+/// claim_timeout on a non-Active match must return InvalidState.
+#[test]
+fn test_claim_timeout_on_pending_match_fails() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "claim_pending"),
+        &Platform::Lichess,
+    );
+    // Only one deposit — still Pending
+    client.deposit(&id, &player1);
+
+    let current = env.ledger().sequence();
+    env.ledger().set_sequence_number(current + crate::TIMEOUT_LEDGERS + 1);
+
+    assert_eq!(
+        client.try_claim_timeout(&id, &player1),
+        Err(Ok(Error::InvalidState))
+    );
+}
+
+// ── finalize_result authorization tests ──────────────────────────────────────
+
+/// finalize_result called by a random account must return Unauthorized.
+#[test]
+fn test_finalize_result_by_stranger_fails() {
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "finalize_unauth"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    client.submit_result(
+        &id,
+        &String::from_str(&env, "finalize_unauth"),
+        &Winner::Player1,
+        &oracle,
+    );
+
+    // Advance past dispute window
+    let current = env.ledger().sequence();
+    env.ledger().set_sequence_number(current + crate::DISPUTE_WINDOW_LEDGERS + 1);
+
+    let stranger = Address::generate(&env);
+    assert_eq!(
+        client.try_finalize_result(&id, &stranger),
+        Err(Ok(Error::Unauthorized)),
+        "finalize_result by stranger must return Unauthorized"
+    );
+}
+
+/// finalize_result called by player1 (a matched player) must succeed.
+#[test]
+fn test_finalize_result_by_player1_succeeds() {
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "finalize_by_p1"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    client.submit_result(
+        &id,
+        &String::from_str(&env, "finalize_by_p1"),
+        &Winner::Player1,
+        &oracle,
+    );
+
+    let current = env.ledger().sequence();
+    env.ledger().set_sequence_number(current + crate::DISPUTE_WINDOW_LEDGERS + 1);
+
+    client.finalize_result(&id, &player1);
+    assert_eq!(client.get_match(&id).state, MatchState::Completed);
+}
+
+/// finalize_result called by the oracle must succeed.
+#[test]
+fn test_finalize_result_by_oracle_succeeds() {
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "finalize_by_oracle"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    client.submit_result(
+        &id,
+        &String::from_str(&env, "finalize_by_oracle"),
+        &Winner::Player2,
+        &oracle,
+    );
+
+    let current = env.ledger().sequence();
+    env.ledger().set_sequence_number(current + crate::DISPUTE_WINDOW_LEDGERS + 1);
+
+    client.finalize_result(&id, &oracle);
+    assert_eq!(client.get_match(&id).state, MatchState::Completed);
+}
+
+/// finalize_result called by the admin must succeed.
+#[test]
+fn test_finalize_result_by_admin_succeeds() {
+    let (env, contract_id, oracle, player1, player2, token, admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "finalize_by_admin"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    client.submit_result(
+        &id,
+        &String::from_str(&env, "finalize_by_admin"),
+        &Winner::Draw,
+        &oracle,
+    );
+
+    let current = env.ledger().sequence();
+    env.ledger().set_sequence_number(current + crate::DISPUTE_WINDOW_LEDGERS + 1);
+
+    client.finalize_result(&id, &admin);
+    assert_eq!(client.get_match(&id).state, MatchState::Completed);
+}
+
+// ── Active state mutual cancel E2E ───────────────────────────────────────────
+
+/// An Active match can be cancelled by player2 when both players authorize.
+#[test]
+fn test_cancel_active_match_by_player2_succeeds() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let token_client = TokenClient::new(&env, &token);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "active_cancel_p2"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    assert_eq!(client.get_match(&id).state, MatchState::Active);
+
+    // Mutual cancel triggered by player2
+    client.cancel_match(&id, &player2);
+
+    assert_eq!(client.get_match(&id).state, MatchState::Cancelled);
+    assert_eq!(token_client.balance(&player1), 1000);
+    assert_eq!(token_client.balance(&player2), 1000);
+}
+
+/// A completed match still cannot be cancelled after an Active mutual cancel scenario.
+#[test]
+fn test_cancel_completed_match_still_fails() {
+    let (env, contract_id, oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let id = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &String::from_str(&env, "completed_cancel2"),
+        &Platform::Lichess,
+    );
+    client.deposit(&id, &player1);
+    client.deposit(&id, &player2);
+    client.submit_result(
+        &id,
+        &String::from_str(&env, "completed_cancel2"),
+        &Winner::Player1,
+        &oracle,
+    );
+    assert_eq!(client.get_match(&id).state, MatchState::Completed);
+
+    assert_eq!(
+        client.try_cancel_match(&id, &player1),
+        Err(Ok(Error::InvalidState))
+    );
+}
+
+
 //
 // These tests use proptest to generate exhaustive random call sequences and
 // assert that any operation issued in the wrong state is always rejected with
@@ -2482,7 +2845,7 @@ mod proptest_state_machine {
             client.submit_result(&id, &String::from_str(&env, "prop-completed"), &winner, &oracle);
             // Advance ledger past the dispute window
             env.ledger().set_sequence_number(env.ledger().sequence() + 17_281);
-            client.finalize_result(&id);
+            client.finalize_result(&id, &player1);
 
             // After Completed: every mutating call must be rejected
             assert_eq!(
@@ -2575,16 +2938,19 @@ mod proptest_state_machine {
         }
     }
 
-    // ── invariant 3: Active → only valid exit is submit_result ───────────────
+    // ── invariant 3: Active → unilateral cancel rejected, mutual cancel allowed ─────
 
-    /// Once a match is `Active` (both players deposited), `cancel_match` must
-    /// always be rejected with `InvalidState` — the only valid exit from Active
-    /// is through the oracle path.
+    /// Once a match is `Active` (both players deposited), a *unilateral* `cancel_match`
+    /// (only one player's auth) must always be rejected — the contract requires both
+    /// players to authorize. A mutual cancel (both auths present) is allowed and
+    /// should return `Ok`.
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(20))]
 
         #[test]
-        fn prop_active_cancel_always_rejected(cancel_caller_is_p1 in proptest::bool::ANY) {
+        fn prop_active_cancel_unilateral_always_rejected(cancel_caller_is_p1 in proptest::bool::ANY) {
+            use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
+
             let (env, contract_id, _oracle, player1, player2, token, _admin) = prop_setup();
             let client = EscrowContractClient::new(&env, &contract_id);
 
@@ -2599,15 +2965,28 @@ mod proptest_state_machine {
             client.deposit(&id, &player1);
             client.deposit(&id, &player2);
 
-            assert_eq!(client.get_match(&id).state, MatchState::Active);
+            prop_assert_eq!(client.get_match(&id).state, MatchState::Active);
 
-            let caller = if cancel_caller_is_p1 { &player1 } else { &player2 };
+            // Provide only one player's auth — must be rejected
+            let (caller, fn_caller) = if cancel_caller_is_p1 {
+                (&player1, player1.clone())
+            } else {
+                (&player2, player2.clone())
+            };
+            env.mock_auths(&[MockAuth {
+                address: caller,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "cancel_match",
+                    args: (id, fn_caller.clone()).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }]);
+
             let result = client.try_cancel_match(&id, caller);
-
-            prop_assert_eq!(
-                result,
-                Err(Ok(Error::InvalidState)),
-                "cancel_match on Active match must return InvalidState"
+            prop_assert!(
+                result.is_err(),
+                "unilateral cancel_match on Active match must be rejected"
             );
         }
     }
@@ -2703,7 +3082,7 @@ mod proptest_state_machine {
                 client.deposit(&id, &player2);
                 client.submit_result(&id, &game_id, &Winner::Player1, &oracle);
                 env.ledger().set_sequence_number(env.ledger().sequence() + 17_281);
-                client.finalize_result(&id);
+                client.finalize_result(&id, &player1);
             } else {
                 client.cancel_match(&id, &player1);
             }
@@ -2716,7 +3095,7 @@ mod proptest_state_machine {
             prop_assert!(
                 client.try_submit_result(&id, &game_id, &Winner::Player1, &oracle).is_err()
             );
-            prop_assert!(client.try_finalize_result(&id).is_err());
+            prop_assert!(client.try_finalize_result(&id, &player1).is_err());
         }
     }
 }

--- a/contracts/escrow/src/tests_e2e.rs
+++ b/contracts/escrow/src/tests_e2e.rs
@@ -16,7 +16,7 @@ extern crate std;
 
 use super::*;
 use soroban_sdk::{
-    testutils::{Address as _, Events},
+    testutils::{Address as _, Events, Ledger as _},
     token::{Client as TokenClient, StellarAssetClient},
     vec, Address, Env, IntoVal, String, Symbol, TryFromVal,
 };
@@ -774,7 +774,7 @@ fn test_e2e_override_result_then_finalize_payout_to_player2() {
     env.ledger().set_sequence_number(current + 17_281);
 
     // ── Step 5: Finalize result — payout goes to Player2 ────────────────────
-    client.finalize_result(&match_id);
+    client.finalize_result(&match_id, &player1);
 
     // ── Verify state ─────────────────────────────────────────────────────────
     let m = client.get_match(&match_id);
@@ -849,7 +849,7 @@ fn test_e2e_override_draw_to_player1_wins() {
     // Advance past dispute window and finalize
     let current = env.ledger().sequence();
     env.ledger().set_sequence_number(current + 17_281);
-    client.finalize_result(&match_id);
+    client.finalize_result(&match_id, &player1);
 
     assert_eq!(client.get_match(&match_id).state, MatchState::Completed);
     // Player1 wins the full pot
@@ -913,7 +913,7 @@ fn test_e2e_finalize_result_rejected_during_dispute_window() {
 
     // Dispute window is still open — finalize must be rejected
     assert_eq!(
-        client.try_finalize_result(&match_id),
+        client.try_finalize_result(&match_id, &player1),
         Err(Ok(Error::DisputeWindowActive)),
         "finalize_result must be rejected while the dispute window is open"
     );


### PR DESCRIPTION
closes #1007 
closes #1008 
closes #1009 
closes #1010 

## Summary

Resolves four issues reported against `contracts/escrow/src/lib.rs`.

---

### Task 1 — finalize_result: restrict to matched players / oracle / admin (Security · Medium)

**Before:** `finalize_result` accepted no auth and could be called by any account.
**After:** Adds a `caller` parameter. Caller must be `player1`, `player2`, the oracle, or the admin; `require_auth()` is enforced. Any other address receives `Error::Unauthorized`.

New tests: `test_finalize_result_by_stranger_fails`, `test_finalize_result_by_player1_succeeds`, `test_finalize_result_by_oracle_succeeds`, `test_finalize_result_by_admin_succeeds`.

---

### Task 2 — is_paused: eliminate env.clone() on every guarded call (Performance · Low)

**Before:** `pub fn is_paused(env: Env)` — called with `env.clone()` at 4 sites.
**After:** `pub fn is_paused(env: &Env)` — all 4 call sites updated to `&env`. No clones.

---

### Task 3 — claim_timeout: introduce Error::TimeoutNotReached (API Clarity · Medium)

**Before:** When the 7-day period had not elapsed, `claim_timeout` returned `Error::MatchTimedOut` — semantically backwards.
**After:** Returns new `Error::TimeoutNotReached` (code 27) when too early. `Error::MatchTimedOut` is now reserved for when the match has actually timed out.

New tests: `test_claim_timeout_before_period_returns_timeout_not_reached`, `test_claim_timeout_after_period_succeeds`, `test_claim_timeout_by_non_player_fails`, `test_claim_timeout_on_pending_match_fails`.

---

### Task 4 — cancel_match: allow mutual cancel in Active state (Feature · Medium)

**Before:** `cancel_match` rejected Active matches with `Error::InvalidState`. The only exit from Active was the oracle or `claim_timeout` (7-day wait).
**After:** Active matches can be cancelled when **both** `player1` and `player2` authorize. A unilateral cancel still fails. Both stakes are refunded immediately.

Tests updated: `test_cancel_active_match_fails` split into unilateral/mutual tests; `test_cancel_with_both_deposits_requires_auth` updated; proptest renamed and updated to test unilateral-only path.

---

### Bonus fix — pre-existing is_zero_address compilation bug

Fixed double-reference `&env` in `is_zero_address` that prevented the lib from compiling. Now uses XDR `ScAddress` construction.

---

## Tested

- `cargo build -p smile4money-escrow` → clean (0 errors)
- All new tests compile and are exercised by the test suite
