### PR TITLE
tests: cover transfer_admin, fix init arg count, sparse list_results

### DIFF
--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -507,7 +507,7 @@ fn test_cancel_active_match_unilateral_fails() {
     let contract_id = env.register(EscrowContract, ());
     let client = EscrowContractClient::new(&env, &contract_id);
     let safe_address = Address::generate(&env);
-    client.initialize(&oracle, &admin, &token_addr, &safe_address);
+    client.initialize(&oracle, &admin, &token_addr, &safe_address, &None, &None);
     asset_client.mint(&contract_id, &crate::ESCROW_RESERVE_BUFFER_STROOPS);
 
     let expiration = env.ledger().sequence() + 1000000;
@@ -1411,6 +1411,52 @@ fn test_transfer_admin_rejects_zero_address() {
     .unwrap();
 
     assert_eq!(client.try_transfer_admin(&admin, &zero_admin), Err(Ok(Error::InvalidAdmin)));
+}
+
+#[test]
+fn test_transfer_admin_succeeds_and_rotates_admin() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let new_admin = Address::generate(&env);
+
+    // Successful rotation
+    assert!(client.try_transfer_admin(&admin, &new_admin).is_ok());
+
+    // Old admin can no longer perform admin rotation
+    let another = Address::generate(&env);
+    assert_eq!(
+        client.try_transfer_admin(&admin, &another),
+        Err(Ok(Error::Unauthorized))
+    );
+
+    // New admin can now rotate again
+    assert!(client.try_transfer_admin(&new_admin, &another).is_ok());
+}
+
+#[test]
+fn test_transfer_admin_self_transfer_rejected() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    // new_admin == current_admin must be rejected
+    assert_eq!(
+        client.try_transfer_admin(&admin, &admin),
+        Err(Ok(Error::InvalidAdmin))
+    );
+}
+
+#[test]
+fn test_transfer_admin_unauthorized_caller_rejected() {
+    let (env, contract_id, _oracle, _player1, _player2, _token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let impostor = Address::generate(&env);
+
+    // A non-admin caller must be rejected
+    assert_eq!(
+        client.try_transfer_admin(&impostor, &admin),
+        Err(Ok(Error::Unauthorized))
+    );
 }
 
 #[test]

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -868,4 +868,45 @@ mod tests {
         let results = client.list_results(&0u64, &200u32);
         assert_eq!(results.len(), 0);
     }
+
+    #[test]
+    fn test_list_results_sparse_non_contiguous_id_space() {
+        let (env, contract_id) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        // Submit results for non-contiguous match IDs, leaving large gaps.
+        client.submit_result(&0u64, &String::from_str(&env, "game0"), &MatchResult::Player1Wins);
+        client.submit_result(&5u64, &String::from_str(&env, "game5"), &MatchResult::Draw);
+        client.submit_result(&10u64, &String::from_str(&env, "game10"), &MatchResult::Player2Wins);
+
+        // Scan a window covering all three IDs plus the gaps between them.
+        let results = client.list_results(&0u64, &20u32);
+        assert_eq!(
+            results.len(),
+            3,
+            "should return exactly the 3 submitted IDs and skip the gaps"
+        );
+
+        let ids: soroban_sdk::Vec<u64> = soroban_sdk::Vec::from_array(
+            &env,
+            [
+                results.get(0).unwrap().0,
+                results.get(1).unwrap().0,
+                results.get(2).unwrap().0,
+            ],
+        );
+        assert_eq!(ids.get(0).unwrap(), 0u64);
+        assert_eq!(ids.get(1).unwrap(), 5u64);
+        assert_eq!(ids.get(2).unwrap(), 10u64);
+
+        // Starting the scan at a gap (id 1) must still find the later IDs (5 and 10).
+        let from_gap = client.list_results(&1u64, &20u32);
+        assert_eq!(from_gap.len(), 2);
+        assert_eq!(from_gap.get(0).unwrap().0, 5u64);
+        assert_eq!(from_gap.get(1).unwrap().0, 10u64);
+
+        // Starting past the last submitted ID returns nothing.
+        let past_end = client.list_results(&11u64, &20u32);
+        assert_eq!(past_end.len(), 0);
+    }
 }


### PR DESCRIPTION
## Summary

Addresses testing gaps and a compile-breaking test referenced in issues #70, #71, #73 (and confirms #81 is already resolved).

### #71 — `test_cancel_active_match_unilateral_fails` failed to compile

The test called `client.initialize(&oracle, &admin, &token_addr, &safe_address)` with **4** arguments, but the current `initialize` signature requires **6** (`oracle, admin, token, safe_address, dispute_window_ledgers, timeout_ledgers`). Fixed to pass `&None, &None`.

### #70 — No `transfer_admin` coverage

Added three new tests to `contracts/escrow/src/tests.rs`:
- `test_transfer_admin_succeeds_and_rotates_admin` — successful rotation; verifies the old admin loses rights and the new admin gains them.
- `test_transfer_admin_self_transfer_rejected` — `new_admin == current_admin` returns `Error::InvalidAdmin`.
- `test_transfer_admin_unauthorized_caller_rejected` — non-admin caller returns `Error::Unauthorized`.

(The existing `test_transfer_admin_rejects_zero_address` already covers the zero-address case.)

### #73 — No sparse `list_results` coverage

Added `test_list_results_sparse_non_contiguous_id_space` to `contracts/oracle/src/lib.rs`: submits results at non-contiguous IDs `0, 5, 10`, asserts exactly **3** entries are returned with gaps skipped, and verifies scanning from a gap (`1`) and past the end (`11`) behave correctly.

### #81 — dependabot `cargo` ecosystem

Confirmed `.github/dependabot.yml` already contains a `cargo` entry (directory `/`), so Rust/Soroban SDK security patches will be detected. No change required.

## Test plan

- `cargo test -p escrow -p oracle`
- Confirm all new `transfer_admin` tests and the sparse `list_results` test pass.

## Files changed

- `contracts/escrow/src/tests.rs`
- `contracts/oracle/src/lib.rs`

Closes #1571
Closes #1582
Closes #1572
Closes #1574