### PR TITLE
fix: add get_game_id_owner test, remove duplicate oracle test, docume…

### DIFF
--- a/contracts/escrow/src/tests.rs
+++ b/contracts/escrow/src/tests.rs
@@ -3132,6 +3132,54 @@ fn test_list_matches_after_limit() {
     assert_eq!(result.get(9), 15);
 }
 
+/// Issue #68: get_game_id_owner must return the match_id that registered a
+/// given game_id, and None for unregistered game_ids.
+#[test]
+fn test_get_game_id_owner_returns_match_id_and_none_for_unknown() {
+    let (env, contract_id, _oracle, player1, player2, token, _admin, _safe_address) = setup();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let game_a = String::from_str(&env, "game_owner_a");
+    let game_b = String::from_str(&env, "game_owner_b");
+    let game_unknown = String::from_str(&env, "game_owner_unknown");
+
+    let id_a = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &game_a,
+        &Platform::Lichess,
+    );
+    let id_b = client.create_match(
+        &player1,
+        &player2,
+        &100,
+        &token,
+        &game_b,
+        &Platform::Lichess,
+    );
+
+    // Registered game_ids return their owning match_id.
+    assert_eq!(
+        client.get_game_id_owner(&game_a),
+        Some(id_a),
+        "registered game_id must return its match_id"
+    );
+    assert_eq!(
+        client.get_game_id_owner(&game_b),
+        Some(id_b),
+        "registered game_id must return its match_id"
+    );
+
+    // Unregistered game_id returns None.
+    assert_eq!(
+        client.get_game_id_owner(&game_unknown),
+        None,
+        "unregistered game_id must return None"
+    );
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Issue #1122 — Property-based tests for state machine transition invariants
 // ═══════════════════════════════════════════════════════════════════════════

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -404,40 +404,6 @@ mod tests {
     }
 
     #[test]
-    fn test_non_admin_cannot_submit_result() {
-        let env = Env::default();
-        let admin = Address::generate(&env);
-        let non_admin = Address::generate(&env);
-        let contract_id = env.register(OracleContract, ());
-        let client = OracleContractClient::new(&env, &contract_id);
-        client.initialize(&admin);
-
-        use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
-        env.mock_auths(&[MockAuth {
-            address: &non_admin,
-            invoke: &MockAuthInvoke {
-                contract: &contract_id,
-                fn_name: "submit_result",
-                args: (
-                    0u64,
-                    String::from_str(&env, "game"),
-                    MatchResult::Player1Wins,
-                )
-                    .into_val(&env),
-                sub_invokes: &[],
-            },
-        }]);
-
-        assert!(client
-            .try_submit_result(
-                &0u64,
-                &String::from_str(&env, "game"),
-                &MatchResult::Player1Wins
-            )
-            .is_err());
-    }
-
-    #[test]
     fn test_submit_result_by_non_admin_returns_unauthorized() {
         let env = Env::default();
         let admin = Address::generate(&env);

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -450,6 +450,55 @@ loop {
 
 ---
 
+#### `list_matches_after`
+
+Retrieve a paginated list of match IDs using **cursor-based** (keyset) pagination, a more robust alternative to `list_matches`.
+
+**Signature:**
+```rust
+pub fn list_matches_after(env: Env, after_match_id: u64, limit: u32) -> Vec<u64>
+```
+
+**Parameters:**
+- `after_match_id`: Return IDs strictly greater than this value. Use `u64::MAX` to start from the beginning.
+- `limit`: Maximum number of match IDs to return (capped at 100)
+
+**Returns:**
+- `Vec<u64>`: Vector of match IDs greater than `after_match_id`, up to `limit` entries
+
+**Behavior:**
+- Returns IDs in the range `(after_match_id, after_match_id + limit]` (capped at 100 iterations)
+- **Unambiguous end-of-data**: an empty result always means there are no further matches. Unlike offset-based `list_matches`, a sparse ID space cannot produce a false "gap"
+- Cursor reuse is safe: the same cursor remains valid even if the contract state changes between calls
+- If fewer matches exist after the cursor, only the available IDs are returned
+
+**Pagination Example:**
+```rust
+let mut cursor = u64::MAX; // start before all IDs
+loop {
+    let matches = escrow.list_matches_after(&cursor, &100);
+    if matches.is_empty() {
+        break; // Reached the end of data
+    }
+
+    // Process matches...
+    for match_id in &matches {
+        let match_data = escrow.get_match(match_id);
+        println!("Match {}: {:?}", match_id, match_data.state);
+    }
+
+    // Advance the cursor using the last returned ID
+    cursor = matches.get(matches.len() - 1);
+}
+```
+
+**Notes:**
+- Prefer this function over `list_matches` when iterating matches in sparse ID spaces (e.g. many cancelled matches), since it never misses entries
+- Requesting a `limit` greater than 100 does not error; it is silently capped at 100
+- To detect the last page: an empty vector indicates the end of data
+
+---
+
 #### `list_results`
 
 Retrieve a paginated list of oracle results.


### PR DESCRIPTION
## Summary

- **#68** Add `test_get_game_id_owner_returns_match_id_and_none_for_unknown` covering correct match ID return for registered `game_ids` and `None` for unknown IDs (`contracts/escrow/src/tests.rs`).
- **#72** Remove duplicate oracle test `test_non_admin_cannot_submit_result`; keep `test_submit_result_by_non_admin_returns_unauthorized`, which additionally asserts the result is not stored after the rejected submission (`contracts/oracle/src/lib.rs`).
- **#78** Document `list_matches_after` cursor-based pagination in `docs/api-reference.md` (signature, parameters, behavior, unambiguous EOF, and a cursor-reuse pagination example).
- **#67** `list_matches_after` is already covered by 6 existing tests (empty/EOF signal, cursor advancement, limit enforcement), so no new tests were required.

## Test plan

- `cargo test` for `contracts/escrow` — new `get_game_id_owner` test passes.
- `cargo test` for `contracts/oracle` — duplicate removed; remaining non-admin test passes.

Closes #1568
Closes #1569
Closes #1573
Closes #1579