### PR TITLE
fix(frontend): warn when match refresh fails

### DIFF
--- a/apps/frontend/src/components/MatchStatus.tsx
+++ b/apps/frontend/src/components/MatchStatus.tsx
@@ -413,6 +413,14 @@ export function MatchStatus({
       <div className="match-id-display" data-testid="match-id-display">
         Match ID: <strong>{matchData.id}</strong>
       </div>
+      {fetchStatus === 'error' && (
+        <div className="feedback warning" role="alert" data-testid="match-refresh-warning">
+          <span>Unable to refresh — showing last known state.</span>{' '}
+          <button type="button" className="btn btn-retry" onClick={fetchMatch}>
+            Retry?
+          </button>
+        </div>
+      )}
       {renderStateContent()}
     </div>
   );

--- a/apps/frontend/tests/MatchStatus.test.tsx
+++ b/apps/frontend/tests/MatchStatus.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { MatchStatus } from '../src/components/MatchStatus';
 
@@ -89,6 +89,41 @@ describe('MatchStatus — state rendering with match data', () => {
     await waitFor(() => {
       expect(screen.getByTestId('state-active')).toBeInTheDocument();
     });
+  });
+
+  it('warns when a polling refresh fails while showing cached data', async () => {
+    vi.useFakeTimers();
+    const onFetchMatch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: '123',
+        state: 'Active',
+        player1: 'GPLAYER1ABC',
+        player2: 'GPLAYER2XYZ',
+        stakeAmount: '100',
+        token: 'xlm',
+        platform: 'lichess',
+        gameId: 'game-abc',
+      })
+      .mockRejectedValueOnce(new Error('Network unavailable'));
+
+    render(<MatchStatus matchId="123" onFetchMatch={onFetchMatch} />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('state-active')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('match-refresh-warning')).toHaveTextContent(
+      'Unable to refresh — showing last known state.',
+    );
+    expect(screen.getByTestId('state-active')).toBeInTheDocument();
+    vi.useRealTimers();
   });
 
   it('renders completed state with winner', async () => {


### PR DESCRIPTION
Closes #1603 
Closes #1604 
Closes #1605 
Closes #1606


## Summary
- show a non-blocking warning when polling fails after match data has loaded
- preserve and clearly identify the last known match state
- provide a functional Retry? action
- add regression coverage for failed polling refreshes

## Validation
- `cd apps/frontend && npm test -- --run tests/MatchStatus.test.tsx` passed: 21 tests
- `npm run build` is currently blocked by pre-existing TypeScript errors in `apps/frontend/src/App.tsx` unrelated to this change