### PR TITLE
Fix case-insensitive match self-check

### DIFF
--- a/apps/backend/src/routes/matches.ts
+++ b/apps/backend/src/routes/matches.ts
@@ -98,7 +98,7 @@ router.post('/', async (req, res) => {
     return res.status(400).json({ error: 'platform must be lichess or chessdotcom' });
   }
 
-  if (req.address === player2) {
+  if (req.address?.toUpperCase() === player2.toUpperCase()) {
     return res.status(400).json({ error: 'player1 and player2 must be different addresses' });
   }
 

--- a/apps/backend/tests/matches.test.ts
+++ b/apps/backend/tests/matches.test.ts
@@ -91,6 +91,23 @@ describe('POST /api/matches', () => {
     expect(response.status).toBe(400);
   });
 
+  it('returns 400 when player2 matches the JWT address regardless of case', async () => {
+    const player1Address = 'GPLAYER1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    const response = await request(app)
+      .post('/api/matches')
+      .set('Authorization', `Bearer ${makeToken(player1Address.toLowerCase())}`)
+      .send({
+        player2: player1Address,
+        stakeAmount: 100,
+        token: 'XLM',
+        gameId: 'lichess-game-abc123',
+        platform: 'lichess',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('player1 and player2 must be different addresses');
+  });
+
   it('returns 400 when stakeAmount is missing', async () => {
     mockLichessGameFound('lichess-game-abc123');
     const response = await request(app)


### PR DESCRIPTION
closes #1623 
closes #1624 
closes #1625 
closes #1626 


Normalize both Stellar addresses before the match self-check so mixed-case JWT payloads cannot bypass same-player validation.

Changes:
- Compare `req.address` and `player2` using uppercase normalization.
- Add a regression test covering a lowercase JWT address.

Validation:
- `npm test -- --run tests/matches.test.ts` passes: 19 tests.
- `npm run build` remains blocked by pre-existing syntax errors in `src/queue.ts` and `tests/queue.test.ts`.