### PR TITLE
fix(frontend): network hook, pagination, a11y, CreateMatch forwarding

### DIFF
--- a/apps/frontend/src/components/CreateMatch.tsx
+++ b/apps/frontend/src/components/CreateMatch.tsx
@@ -26,6 +26,8 @@ interface CreateMatchProps {
     gameId: string;
     platform: Platform;
     platformUsername?: string;
+    networkPassphrase: string;
+    rpcUrl: string;
   }) => Promise<string>;
 }
 
@@ -265,6 +267,8 @@ export function CreateMatch({
           gameId: formData.gameId,
           platform: formData.platform,
           platformUsername: formData.platformUsername || undefined,
+          networkPassphrase,
+          rpcUrl,
         });
 
         if (result) {
@@ -278,7 +282,7 @@ export function CreateMatch({
         setErrorMsg(err instanceof Error ? err.message : 'Failed to create match');
       }
     },
-    [formData, player1Address, token, apiBaseUrl, knownGameIds, onCreateMatch],
+    [formData, player1Address, token, apiBaseUrl, knownGameIds, onCreateMatch, networkPassphrase, rpcUrl],
   );
 
   function resetForm() {

--- a/apps/frontend/src/components/NetworkBadge.tsx
+++ b/apps/frontend/src/components/NetworkBadge.tsx
@@ -1,33 +1,28 @@
-const NETWORK_LABELS: Record<string, string> = {
-  mainnet: 'Mainnet',
-  testnet: 'Testnet',
-  futurenet: 'Futurenet',
-  standalone: 'Standalone',
-};
-
-const NETWORK_COLORS: Record<string, string> = {
-  mainnet: 'bg-green-600',
-  testnet: 'bg-amber-500',
-  futurenet: 'bg-orange-500',
-  standalone: 'bg-gray-400',
-};
+import React from 'react';
+import { useNetworkStatus, NETWORK_COLORS } from '../hooks/useNetworkStatus';
 
 interface NetworkBadgeProps {
+  /** Override the network to display. Defaults to the app's expected network. */
   network?: string;
 }
 
 export function NetworkBadge({ network }: NetworkBadgeProps) {
-  const net = network ?? import.meta.env.VITE_STELLAR_NETWORK ?? 'testnet';
-  const label = NETWORK_LABELS[net] ?? net;
-  const color = NETWORK_COLORS[net] ?? 'bg-gray-400';
+  const { expectedNetwork, expectedColor, expectedLabel, walletNetwork, walletLabel } =
+    useNetworkStatus(network ?? null);
+
+  // When an explicit `network` prop is provided it is treated as the
+  // "wallet network"; otherwise fall back to the expected network.
+  const displayNet = walletNetwork ?? expectedNetwork;
+  const displayLabel = walletLabel ?? expectedLabel;
+  const displayColor = walletNetwork ? (NETWORK_COLORS[walletNetwork] ?? 'bg-gray-400') : expectedColor;
 
   return (
     <span
-      className={`inline-block rounded px-2 py-0.5 text-xs font-semibold uppercase tracking-wide ${color} text-white`}
+      className={`inline-block rounded px-2 py-0.5 text-xs font-semibold uppercase tracking-wide ${displayColor} text-white`}
       data-testid="network-badge"
-      data-network={net}
+      data-network={displayNet}
     >
-      {label}
+      {displayLabel}
     </span>
   );
 }

--- a/apps/frontend/src/components/NetworkBanner.tsx
+++ b/apps/frontend/src/components/NetworkBanner.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-
-const EXPECTED_NETWORK = import.meta.env.VITE_STELLAR_NETWORK ?? 'testnet';
+import { useNetworkStatus } from '../hooks/useNetworkStatus';
 
 interface NetworkBannerProps {
   walletNetwork: string | null;
 }
 
 export function NetworkBanner({ walletNetwork }: NetworkBannerProps) {
-  if (!walletNetwork || walletNetwork === EXPECTED_NETWORK) {
+  const { isMismatch, walletNetwork: currentNetwork, expectedNetwork } = useNetworkStatus(walletNetwork);
+
+  if (!isMismatch) {
     return null;
   }
 
@@ -17,8 +18,8 @@ export function NetworkBanner({ walletNetwork }: NetworkBannerProps) {
       data-testid="network-banner"
       className="w-full bg-red-600 px-4 py-3 text-center text-sm font-medium text-white"
     >
-      Wrong network detected: your wallet is on <strong>{walletNetwork}</strong> but this app
-      requires <strong>{EXPECTED_NETWORK}</strong>.{' '}
+      Wrong network detected: your wallet is on <strong>{currentNetwork}</strong> but this app
+      requires <strong>{expectedNetwork}</strong>.{' '}
       <a
         href="https://www.freighter.app/"
         target="_blank"

--- a/apps/frontend/src/components/forms/RegistrationForm.tsx
+++ b/apps/frontend/src/components/forms/RegistrationForm.tsx
@@ -52,46 +52,92 @@ export function RegistrationForm({ onSubmit }: RegistrationFormProps) {
   }
 
   return (
-    <form onSubmit={handleSubmit} noValidate>
+    <form onSubmit={handleSubmit} noValidate aria-label="Registration form">
+      {/* Email */}
       <div>
-        <label htmlFor="email">Email</label>
+        <label htmlFor="reg-email">
+          Email <span aria-hidden="true">*</span>
+        </label>
         <input
-          id="email"
+          id="reg-email"
           type="email"
           value={fields.email}
           onChange={(e) => update('email', e.target.value)}
           onBlur={() => blur('email')}
-          aria-describedby={errors.email ? 'email-error' : undefined}
+          aria-required="true"
+          aria-invalid={errors.email ? 'true' : 'false'}
+          aria-describedby={errors.email ? 'reg-email-error' : undefined}
+          autoComplete="email"
         />
-        {errors.email && <span id="email-error">{errors.email}</span>}
+        {errors.email && (
+          <span id="reg-email-error" role="alert" aria-live="polite">
+            {errors.email}
+          </span>
+        )}
       </div>
+
+      {/* Password */}
       <div>
-        <label htmlFor="password">Password</label>
+        <label htmlFor="reg-password">
+          Password <span aria-hidden="true">*</span>
+        </label>
         <input
-          id="password"
+          id="reg-password"
           type="password"
           value={fields.password}
           onChange={(e) => update('password', e.target.value)}
           onBlur={() => blur('password')}
-          aria-describedby={errors.password ? 'password-error' : undefined}
+          aria-required="true"
+          aria-invalid={errors.password ? 'true' : 'false'}
+          aria-describedby={
+            errors.password
+              ? 'reg-password-error'
+              : 'reg-password-hint'
+          }
+          autoComplete="new-password"
         />
-        {errors.password && <span id="password-error">{errors.password}</span>}
+        <span id="reg-password-hint" className="field-hint">
+          At least 8 characters, one uppercase letter, and one number.
+        </span>
+        {errors.password && (
+          <span id="reg-password-error" role="alert" aria-live="polite">
+            {errors.password}
+          </span>
+        )}
       </div>
+
+      {/* Confirm Password */}
       <div>
-        <label htmlFor="confirmPassword">Confirm Password</label>
+        <label htmlFor="reg-confirm-password">
+          Confirm Password <span aria-hidden="true">*</span>
+        </label>
         <input
-          id="confirmPassword"
+          id="reg-confirm-password"
           type="password"
           value={fields.confirmPassword}
           onChange={(e) => update('confirmPassword', e.target.value)}
           onBlur={() => blur('confirmPassword')}
-          aria-describedby={errors.confirmPassword ? 'confirm-error' : undefined}
+          aria-required="true"
+          aria-invalid={errors.confirmPassword ? 'true' : 'false'}
+          aria-describedby={errors.confirmPassword ? 'reg-confirm-error' : undefined}
+          autoComplete="new-password"
         />
-        {errors.confirmPassword && <span id="confirm-error">{errors.confirmPassword}</span>}
+        {errors.confirmPassword && (
+          <span id="reg-confirm-error" role="alert" aria-live="polite">
+            {errors.confirmPassword}
+          </span>
+        )}
       </div>
-      <button type="submit" disabled={submitting}>
-        Register
+
+      <button type="submit" disabled={submitting} aria-busy={submitting}>
+        {submitting ? 'Registering…' : 'Register'}
       </button>
+
+      {submitted && !submitting && Object.keys(errors).length === 0 && (
+        <p role="status" aria-live="polite">
+          Registration submitted successfully.
+        </p>
+      )}
     </form>
   );
 }

--- a/apps/frontend/src/hooks/useNetworkStatus.ts
+++ b/apps/frontend/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,58 @@
+/**
+ * useNetworkStatus
+ *
+ * Single source of truth for network detection logic shared by
+ * NetworkBanner and NetworkBadge. Any change to how the expected
+ * network is resolved or how a mismatch is detected only needs to
+ * be made here.
+ */
+
+const EXPECTED_NETWORK = import.meta.env.VITE_STELLAR_NETWORK ?? 'testnet';
+
+export const NETWORK_LABELS: Record<string, string> = {
+  mainnet: 'Mainnet',
+  testnet: 'Testnet',
+  futurenet: 'Futurenet',
+  standalone: 'Standalone',
+};
+
+export const NETWORK_COLORS: Record<string, string> = {
+  mainnet: 'bg-green-600',
+  testnet: 'bg-amber-500',
+  futurenet: 'bg-orange-500',
+  standalone: 'bg-gray-400',
+};
+
+export interface NetworkStatus {
+  /** The network name the app expects (from VITE_STELLAR_NETWORK). */
+  expectedNetwork: string;
+  /** The wallet's current network, or null if unknown / not connected. */
+  walletNetwork: string | null;
+  /** True when the wallet is on a different network than expected. */
+  isMismatch: boolean;
+  /** Human-readable label for the expected network. */
+  expectedLabel: string;
+  /** Tailwind colour class for the expected network badge. */
+  expectedColor: string;
+  /** Human-readable label for the wallet's current network (falls back to the raw value). */
+  walletLabel: string | null;
+}
+
+/**
+ * Returns derived network status from a raw wallet network string.
+ *
+ * @param walletNetwork - The network string reported by the connected wallet,
+ *   or null when no wallet is connected.
+ */
+export function useNetworkStatus(walletNetwork: string | null): NetworkStatus {
+  const isMismatch = !!walletNetwork && walletNetwork !== EXPECTED_NETWORK;
+
+  return {
+    expectedNetwork: EXPECTED_NETWORK,
+    walletNetwork,
+    isMismatch,
+    expectedLabel: NETWORK_LABELS[EXPECTED_NETWORK] ?? EXPECTED_NETWORK,
+    expectedColor: NETWORK_COLORS[EXPECTED_NETWORK] ?? 'bg-gray-400',
+    walletLabel: walletNetwork ? (NETWORK_LABELS[walletNetwork] ?? walletNetwork) : null,
+  };
+}

--- a/apps/frontend/src/pages/History.tsx
+++ b/apps/frontend/src/pages/History.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import type { WalletStatus } from '../types';
 
 const HORIZON_URL = 'https://horizon-testnet.stellar.org';
+const PAGE_SIZE = 20;
 
 interface HistoryProps {
   walletState: WalletStatus;
@@ -20,6 +21,14 @@ interface HorizonTransaction {
   };
 }
 
+interface HorizonResponse {
+  _embedded?: { records: HorizonTransaction[] };
+  _links?: {
+    next?: { href: string };
+    prev?: { href: string };
+  };
+}
+
 interface HistoryRow {
   id: string;
   matchId: string;
@@ -30,7 +39,7 @@ interface HistoryRow {
   date: string;
 }
 
-function parseCursor(href: string) {
+function parseCursor(href: string): string | null {
   try {
     const url = new URL(href);
     return url.searchParams.get('cursor');
@@ -39,77 +48,98 @@ function parseCursor(href: string) {
   }
 }
 
+function mapRecord(record: HorizonTransaction, publicKey: string): HistoryRow {
+  const matchId =
+    record.memo && !Number.isNaN(Number(record.memo)) ? record.memo : '—';
+  const opponent =
+    record.source_account === publicKey ? 'Unknown' : record.source_account;
+  const stake = record.fee_charged ? `${record.fee_charged} stroops` : '—';
+  const result = record.successful ? 'Success' : 'Failed';
+  const payout = record.successful ? 'Confirmed' : 'Failed';
+  return {
+    id: record.hash,
+    matchId,
+    opponent,
+    stake,
+    result,
+    payout,
+    date: new Date(record.created_at).toLocaleString(),
+  };
+}
+
 export function History({ walletState, publicKey }: HistoryProps) {
   const [history, setHistory] = useState<HistoryRow[]>([]);
   const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [cursor, setCursor] = useState<string | null>(null);
+  // Cursor for the *next* page; null means we are on the first page or there
+  // are no more results.
   const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const [prevCursor, setPrevCursor] = useState<string | null>(null);
 
+  /** Fetch a page of transactions. When `cursor` is null the first page is
+   *  fetched; otherwise the page starting after `cursor` is fetched and
+   *  appended to the existing history (Load More behaviour). */
+  const fetchPage = useCallback(
+    async (cursor: string | null, append: boolean) => {
+      if (!publicKey) return;
+
+      append ? setLoadingMore(true) : setLoading(true);
+      setError(null);
+
+      const url = new URL(`${HORIZON_URL}/accounts/${publicKey}/transactions`);
+      url.searchParams.set('limit', String(PAGE_SIZE));
+      url.searchParams.set('order', 'desc');
+      if (cursor) url.searchParams.set('cursor', cursor);
+
+      try {
+        const response = await fetch(url.toString());
+        if (!response.ok) {
+          throw new Error('Unable to load transaction history');
+        }
+        const data = (await response.json()) as HorizonResponse;
+        const records: HorizonTransaction[] = data._embedded?.records ?? [];
+
+        const rows = records.map((r) => mapRecord(r, publicKey));
+
+        setHistory((prev) => (append ? [...prev, ...rows] : rows));
+
+        // If the API returned fewer records than PAGE_SIZE there are no more
+        // pages, so we intentionally clear nextCursor to hide the Load More
+        // button.
+        const nextHref = data._links?.next?.href;
+        const derived = nextHref ? parseCursor(nextHref) : null;
+        setNextCursor(records.length < PAGE_SIZE ? null : derived);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load history');
+      } finally {
+        append ? setLoadingMore(false) : setLoading(false);
+      }
+    },
+    [publicKey],
+  );
+
+  // Reset and reload whenever the connected wallet changes.
   useEffect(() => {
     if (walletState !== 'connected' || !publicKey) {
       setHistory([]);
+      setNextCursor(null);
       setError(null);
       setLoading(false);
       return;
     }
 
-    let active = true;
-    setLoading(true);
-    setError(null);
+    setNextCursor(null);
+    void fetchPage(null, false);
+    // fetchPage is stable (memoised on publicKey); re-run when publicKey or
+    // walletState changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [publicKey, walletState]);
 
-    const url = new URL(`${HORIZON_URL}/accounts/${publicKey}/transactions`);
-    url.searchParams.set('limit', '10');
-    url.searchParams.set('order', 'desc');
-    if (cursor) url.searchParams.set('cursor', cursor);
-
-    fetch(url.toString())
-      .then(async (response) => {
-        if (!response.ok) {
-          throw new Error('Unable to load transaction history');
-        }
-        return response.json();
-      })
-      .then((data) => {
-        if (!active) return;
-        const records: HorizonTransaction[] = data._embedded?.records ?? [];
-        setHistory(
-          records.map((record) => {
-            const matchId = record.memo && !Number.isNaN(Number(record.memo)) ? record.memo : '—';
-            const opponent =
-              record.source_account === publicKey ? 'Unknown' : record.source_account;
-            const stake = record.fee_charged ? `${record.fee_charged} stroops` : '—';
-            const result = record.successful ? 'Success' : 'Failed';
-            const payout = record.successful ? 'Confirmed' : 'Failed';
-            return {
-              id: record.hash,
-              matchId,
-              opponent,
-              stake,
-              result,
-              payout,
-              date: new Date(record.created_at).toLocaleString(),
-            };
-          }),
-        );
-
-        setNextCursor(data._links?.next?.href ? parseCursor(data._links.next.href) : null);
-        setPrevCursor(data._links?.prev?.href ? parseCursor(data._links.prev.href) : null);
-      })
-      .catch((err) => {
-        if (!active) return;
-        setError(err instanceof Error ? err.message : 'Failed to load history');
-      })
-      .finally(() => {
-        if (!active) return;
-        setLoading(false);
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [publicKey, walletState, cursor]);
+  function handleLoadMore() {
+    if (nextCursor && !loadingMore) {
+      void fetchPage(nextCursor, true);
+    }
+  }
 
   if (walletState !== 'connected') {
     return (
@@ -123,61 +153,71 @@ export function History({ walletState, publicKey }: HistoryProps) {
   return (
     <section className="history-page" data-testid="history-page">
       <h2>Match History</h2>
+
       {loading && <p data-testid="history-loading">Loading history…</p>}
+
       {error && (
         <p className="history-error" role="alert" data-testid="history-error">
           {error}
         </p>
       )}
+
       {!loading && !error && history.length === 0 && (
         <p data-testid="history-empty">No matches found for this wallet.</p>
       )}
-      {!loading && !error && history.length > 0 && (
-        <div className="history-table-wrap">
-          <table className="history-table" data-testid="history-table">
-            <thead>
-              <tr>
-                <th>Match ID</th>
-                <th>Opponent</th>
-                <th>Stake</th>
-                <th>Result</th>
-                <th>Payout</th>
-                <th>Date</th>
-              </tr>
-            </thead>
-            <tbody>
-              {history.map((row) => (
-                <tr key={row.id} data-testid="history-row">
-                  <td>{row.matchId}</td>
-                  <td>{row.opponent}</td>
-                  <td>{row.stake}</td>
-                  <td>{row.result}</td>
-                  <td>{row.payout}</td>
-                  <td>{row.date}</td>
+
+      {!loading && history.length > 0 && (
+        <>
+          <div className="history-table-wrap">
+            <table className="history-table" data-testid="history-table">
+              <thead>
+                <tr>
+                  <th>Match ID</th>
+                  <th>Opponent</th>
+                  <th>Stake</th>
+                  <th>Result</th>
+                  <th>Payout</th>
+                  <th>Date</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {history.map((row) => (
+                  <tr key={row.id} data-testid="history-row">
+                    <td>{row.matchId}</td>
+                    <td>{row.opponent}</td>
+                    <td>{row.stake}</td>
+                    <td>{row.result}</td>
+                    <td>{row.payout}</td>
+                    <td>{row.date}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Load More — hidden once all pages are exhausted */}
+          {nextCursor && (
+            <div className="history-load-more">
+              <button
+                type="button"
+                className="btn btn-secondary"
+                disabled={loadingMore}
+                onClick={handleLoadMore}
+                data-testid="history-load-more"
+                aria-busy={loadingMore}
+              >
+                {loadingMore ? 'Loading…' : 'Load more'}
+              </button>
+            </div>
+          )}
+
+          {loadingMore && (
+            <p data-testid="history-loading-more" aria-live="polite">
+              Loading more matches…
+            </p>
+          )}
+        </>
       )}
-      <div className="history-pagination">
-        <button
-          type="button"
-          disabled={!prevCursor || loading}
-          onClick={() => setCursor(prevCursor)}
-          data-testid="history-prev"
-        >
-          Newer
-        </button>
-        <button
-          type="button"
-          disabled={!nextCursor || loading}
-          onClick={() => setCursor(nextCursor)}
-          data-testid="history-next"
-        >
-          Older
-        </button>
-      </div>
     </section>
   );
 }


### PR DESCRIPTION
closes #1607 
closes #1608 
closes #1609 
closes #1610 


## Summary

Four high-priority frontend issues resolved in a single PR.

### 1. Extract `useNetworkStatus` hook (Code Quality)
- Created `apps/frontend/src/hooks/useNetworkStatus.ts` exporting `NETWORK_LABELS`, `NETWORK_COLORS`, `NetworkStatus` interface, and `useNetworkStatus(walletNetwork)`.
- `NetworkBanner` and `NetworkBadge` both import from this hook — duplicated network detection logic is gone.

### 2. Cursor-based Load More pagination in `History.tsx` (Bug / Performance)
- Replaced prev/next pagination with append-based Load More (PAGE_SIZE=20).
- Button hidden when API returns fewer than PAGE_SIZE records, preventing silent data loss beyond the first 100 matches.

### 3. `RegistrationForm.tsx` accessibility (WCAG 2.1 SC 1.3.1 / 2.4.6)
- Added `aria-required`, `aria-invalid`, `aria-describedby` on all inputs.
- Error spans carry `role=alert` and `aria-live=polite`.
- Added `aria-label` on the form; `role=status` success message after submit.

### 4. Forward `networkPassphrase` / `rpcUrl` in `CreateMatch.tsx` (Bug)
- Updated `onCreateMatch` type to include both fields.
- Both forwarded in `handleSubmit`; both added to `useCallback` deps.

## Files changed
- `apps/frontend/src/hooks/useNetworkStatus.ts` (new)
- `apps/frontend/src/components/NetworkBanner.tsx`
- `apps/frontend/src/components/NetworkBadge.tsx`
- `apps/frontend/src/pages/History.tsx`
- `apps/frontend/src/components/forms/RegistrationForm.tsx`
- `apps/frontend/src/components/CreateMatch.tsx`