### PR TITLE
fix: add dev-mode warning when ToastProvider unmounts with active timers

### DIFF
--- a/apps/frontend/src/components/Toast.tsx
+++ b/apps/frontend/src/components/Toast.tsx
@@ -59,6 +59,12 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   React.useEffect(() => {
     const timers = timersRef.current;
     return () => {
+      if (import.meta.env.DEV && timers.size > 0) {
+        console.warn(
+          `[Toast] Provider unmounting with ${timers.size} active timer(s). ` +
+          'This should not happen in production — check for premature unmounts.',
+        );
+      }
       timers.forEach((timerId) => window.clearTimeout(timerId));
       timers.clear();
     };


### PR DESCRIPTION
## Summary

The Toast.tsx setTimeout memory leak is already fixed (timers tracked via `timersRef`, cleared on dismiss and unmount). This PR adds a **dev-mode-only** `console.warn` when the provider unmounts while timers are still pending, surfacing premature unmount issues during development with zero runtime cost in production.

**Changes:**
- Added `import.meta.env.DEV` check in the `useEffect` cleanup
- Logs warning with active timer count if unmount happens unexpectedly

Closes #1555

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>