### PR TITLE
fix: set document title on NotFound page for better UX

### DIFF
--- a/apps/frontend/src/pages/NotFound.tsx
+++ b/apps/frontend/src/pages/NotFound.tsx
@@ -1,6 +1,11 @@
+import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 
 export function NotFound() {
+  useEffect(() => {
+    document.title = '404 — Page Not Found';
+  }, []);
+
   return (
     <main
       className="dark:bg-slate-950 dark:text-slate-100 flex min-h-screen flex-col items-center justify-center bg-gray-100 px-4 text-slate-900 transition-colors"


### PR DESCRIPTION
## Summary

The 404 catch-all route is already implemented (`main.tsx` has `<Route path="*">` with a styled `NotFound` component). This PR adds a `useEffect` to set `document.title = "404 — Page Not Found"` when the component mounts, so the browser tab clearly indicates the page was not found.

**Changes:**
- Added `useEffect` to set `document.title` on mount
- Imported `useEffect` from React

Closes #1558

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>