### PR TITLE
fix(oracle): reject zero address in transfer_admin

### DIFF
--- a/PR_ORACLE_TRANSFER_ADMIN_ZERO_ADDRESS.md
+++ b/PR_ORACLE_TRANSFER_ADMIN_ZERO_ADDRESS.md
@@ -1,0 +1,86 @@
+# fix(oracle): reject zero address in transfer_admin
+
+## Description
+
+`oracle::transfer_admin` previously accepted any address as `new_admin` without
+validation, including the all-zeroes contract address
+(`CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM`). That address can
+never sign a transaction, so storing it as admin would permanently brick the
+contract — no subsequent `transfer_admin`, `submit_result`, or `withdraw` call
+could ever succeed.
+
+### Changes
+
+**`contracts/oracle/src/errors.rs`**
+- Added `InvalidAdmin = 8` variant with a stable numeric code and doc comment
+  explaining the brick-risk. Existing codes are untouched — no breaking change
+  for clients that inspect raw error codes.
+
+**`contracts/oracle/src/lib.rs`**
+- `transfer_admin`: added a zero-address guard using `Address::from_strkey`
+  against the canonical all-zeroes C-address strkey. Returns
+  `Err(Error::InvalidAdmin)` before any state is written.
+- Updated `transfer_admin` doc comment to document the new `InvalidAdmin` error
+  alongside the existing `Unauthorized` case.
+- Added test `test_transfer_admin_zero_address_returns_invalid_admin` that:
+  - asserts `try_transfer_admin` returns `Err(Ok(Error::InvalidAdmin))` for the
+    zero address
+  - confirms the contract remains fully operational after the rejected call (i.e.
+    `submit_result` still succeeds, verifying the admin slot was not overwritten)
+
+## Type of Change
+
+- [x] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
+- [ ] Documentation update
+
+## Testing
+
+Run the oracle test suite (requires Rust 1.88.0 — same toolchain as CI):
+
+```bash
+cargo test -p smile4money-oracle --lib --verbose
+```
+
+The new test to look for:
+
+```
+test tests::test_transfer_admin_zero_address_returns_invalid_admin ... ok
+```
+
+All pre-existing oracle tests must continue to pass.
+
+- [x] Tests added or updated
+- [ ] Manual testing performed
+
+## Contract Changes
+
+The `Error` enum gains a new variant (`InvalidAdmin = 8`). The numeric
+discriminants of all existing variants are unchanged.
+
+- [ ] ABI breaking? (requires re-deployment of existing contracts)
+- [ ] Storage migration needed?
+- [x] ABI reviewed for breaking changes
+
+> The new error code `8` is additive. Clients that switch on raw error codes and
+> use a catch-all for unknown values are unaffected. Clients with exhaustive
+> matches on the `Error` enum (generated bindings) will need to handle the new
+> variant — this is expected and safe.
+
+## Security
+
+- [x] No secrets committed
+- [x] Security implications considered and documented
+
+This fix closes a contract-bricking vector: a malicious or mistaken admin could
+have called `transfer_admin(zero_address)`, irrecoverably locking all admin-gated
+functionality (`submit_result`, `withdraw`, future `transfer_admin`). The guard is
+applied before `require_auth` writes any state, so no partial update is possible.
+
+## Documentation
+
+- [ ] Relevant docs updated (docs/ folder, README, etc.)
+
+The `transfer_admin` doc comment in `lib.rs` has been updated inline. No separate
+docs-folder changes are needed for this fix.

--- a/contracts/oracle/src/errors.rs
+++ b/contracts/oracle/src/errors.rs
@@ -17,7 +17,8 @@ use soroban_sdk::contracterror;
 /// |  4   | AlreadyInitialized | Contract has already been initialized                    |
 /// |  5   | InvalidGameId      | game_id is empty or exceeds the 64-byte maximum          |
 /// |  6   | TransferFailed     | Token transfer in withdraw failed                        |
-/// |  7   | InvalidAmount      | withdraw amount must be greater than zero               |
+/// |  7   | InvalidAmount      | withdraw amount must be greater than zero                |
+/// |  8   | InvalidAdmin       | new_admin is the zero/burn address                       |
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
@@ -42,4 +43,8 @@ pub enum Error {
 
     /// [E007] Invalid amount supplied to `withdraw` (amount must be > 0).
     InvalidAmount = 7,
+
+    /// [E008] `new_admin` is the zero/burn address. Storing it would permanently
+    /// brick the contract because the zero address can never sign a transaction.
+    InvalidAdmin = 8,
 }

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -220,7 +220,11 @@ impl OracleContract {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::Unauthorized`] if the current admin has not signed the transaction.
+    /// * [`Error::Unauthorized`]  — The current admin has not signed the transaction, or
+    ///   the contract has not been initialized.
+    /// * [`Error::InvalidAdmin`]  — `new_admin` is the all-zeroes contract address
+    ///   (`CAAAA…AAAD2KM`). That address can never sign, so storing it would permanently
+    ///   brick the contract.
     pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), Error> {
         let admin: Address = env
             .storage()
@@ -228,6 +232,21 @@ impl OracleContract {
             .get(&DataKey::Admin)
             .ok_or(Error::Unauthorized)?;
         admin.require_auth();
+
+        // Reject the zero/burn address. The all-zeroes contract address
+        // (CAAAA...AAAD2KM in strkey encoding) can never sign a transaction.
+        // Storing it as admin would permanently brick the contract — no future
+        // transfer_admin, submit_result, or withdraw call could ever succeed.
+        let zero_addr = Address::from_strkey(
+            &env,
+            &soroban_sdk::String::from_str(
+                &env,
+                "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            ),
+        );
+        if new_admin == zero_addr {
+            return Err(Error::InvalidAdmin);
+        }
 
         // If the new admin is the same as the current admin, treat this as a no-op.
         // Do not update storage or emit an `adm_xfer` event to avoid misleading
@@ -893,5 +912,38 @@ mod tests {
         // Starting past the last submitted ID returns nothing.
         let past_end = client.list_results(&11u64, &20u32);
         assert_eq!(past_end.len(), 0);
+    }
+
+    // ── Issue #1513: transfer_admin must reject the zero/burn address ─────────
+
+    #[test]
+    fn test_transfer_admin_zero_address_returns_invalid_admin() {
+        let (env, contract_id) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        // The all-zeroes contract address (C-strkey) can never sign a transaction.
+        // Passing it to transfer_admin must return Error::InvalidAdmin so the
+        // contract cannot be permanently bricked.
+        let zero_addr = Address::from_strkey(
+            &env,
+            &String::from_str(
+                &env,
+                "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            ),
+        );
+
+        assert_eq!(
+            client.try_transfer_admin(&zero_addr),
+            Err(Ok(Error::InvalidAdmin)),
+            "transfer_admin must reject the zero address with InvalidAdmin"
+        );
+
+        // Confirm the admin was NOT updated — the contract is still functional.
+        client.submit_result(
+            &0u64,
+            &String::from_str(&env, "game1"),
+            &MatchResult::Player1Wins,
+        );
+        assert!(client.has_result(&0u64), "contract must remain operational after rejected transfer");
     }
 }


### PR DESCRIPTION
Closes #1513 

# fix(oracle): reject zero address in transfer_admin

## Description

`oracle::transfer_admin` previously accepted any address as `new_admin` without
validation, including the all-zeroes contract address
(`CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM`). That address can
never sign a transaction, so storing it as admin would permanently brick the
contract — no subsequent `transfer_admin`, `submit_result`, or `withdraw` call
could ever succeed.

### Changes

**`contracts/oracle/src/errors.rs`**
- Added `InvalidAdmin = 8` variant with a stable numeric code and doc comment
  explaining the brick-risk. Existing codes are untouched — no breaking change
  for clients that inspect raw error codes.

**`contracts/oracle/src/lib.rs`**
- `transfer_admin`: added a zero-address guard using `Address::from_strkey`
  against the canonical all-zeroes C-address strkey. Returns
  `Err(Error::InvalidAdmin)` before any state is written.
- Updated `transfer_admin` doc comment to document the new `InvalidAdmin` error
  alongside the existing `Unauthorized` case.
- Added test `test_transfer_admin_zero_address_returns_invalid_admin` that:
  - asserts `try_transfer_admin` returns `Err(Ok(Error::InvalidAdmin))` for the
    zero address
  - confirms the contract remains fully operational after the rejected call (i.e.
    `submit_result` still succeeds, verifying the admin slot was not overwritten)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## Testing

Run the oracle test suite (requires Rust 1.88.0 — same toolchain as CI):

```bash
cargo test -p smile4money-oracle --lib --verbose
```

The new test to look for:

```
test tests::test_transfer_admin_zero_address_returns_invalid_admin ... ok
```

All pre-existing oracle tests must continue to pass.

- [x] Tests added or updated
- [ ] Manual testing performed

## Contract Changes

The `Error` enum gains a new variant (`InvalidAdmin = 8`). The numeric
discriminants of all existing variants are unchanged.

- [ ] ABI breaking? (requires re-deployment of existing contracts)
- [ ] Storage migration needed?
- [x] ABI reviewed for breaking changes

> The new error code `8` is additive. Clients that switch on raw error codes and
> use a catch-all for unknown values are unaffected. Clients with exhaustive
> matches on the `Error` enum (generated bindings) will need to handle the new
> variant — this is expected and safe.

## Security

- [x] No secrets committed
- [x] Security implications considered and documented

This fix closes a contract-bricking vector: a malicious or mistaken admin could
have called `transfer_admin(zero_address)`, irrecoverably locking all admin-gated
functionality (`submit_result`, `withdraw`, future `transfer_admin`). The guard is
applied before `require_auth` writes any state, so no partial update is possible.

## Documentation

- [ ] Relevant docs updated (docs/ folder, README, etc.)

The `transfer_admin` doc comment in `lib.rs` has been updated inline. No separate
docs-folder changes are needed for this fix.
