### PR TITLE
fix(oracle): validate game_id character set in submit_result

### DIFF
--- a/PR_ORACLE_GAME_ID_CHARSET_VALIDATION.md
+++ b/PR_ORACLE_GAME_ID_CHARSET_VALIDATION.md
@@ -1,0 +1,96 @@
+# fix(oracle): validate game_id character set in submit_result
+
+## Description
+
+`oracle::submit_result` checked `game_id` length (1–64 bytes) but not its
+character content. The escrow contract enforces `[A-Za-z0-9_-]` for `game_id`
+on its side. If the oracle stored a `game_id` containing null bytes, control
+characters, whitespace, or non-ASCII sequences, the stored `ResultEntry.game_id`
+would permanently diverge from the escrow's accepted format, triggering an
+irrecoverable `GameIdMismatch` error that locks player funds.
+
+### Changes
+
+**`contracts/oracle/src/lib.rs`**
+- Added `is_valid_game_id` free function at module scope. It copies the string
+  into a fixed 64-byte stack buffer (no heap allocation in the WASM guest) and
+  checks every byte against `[A-Za-z0-9_-]`. The implementation is a verbatim
+  mirror of the identical helper in the escrow contract, guaranteeing the two
+  contracts always agree on what constitutes a valid `game_id`.
+- `submit_result`: added the character-set check immediately after the length
+  check. Both failures return `Error::InvalidGameId` — no new error code needed,
+  and no ABI break.
+- Updated `submit_result` doc comment to document the charset constraint and
+  expand the `InvalidGameId` error description.
+- Added 7 focused tests (see Testing section).
+
+**`contracts/oracle/src/errors.rs`**
+- Updated the `InvalidGameId = 5` table row and doc comment to describe the
+  full validation rule: empty, over-length, _or_ characters outside
+  `[A-Za-z0-9_-]`. No numeric code change — fully backwards compatible.
+
+## Type of Change
+
+- [x] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
+- [ ] Documentation update
+
+## Testing
+
+Run the oracle test suite (requires Rust 1.88.0 — same toolchain as CI):
+
+```bash
+cargo test -p smile4money-oracle --lib --verbose
+```
+
+New tests to look for:
+
+```
+test tests::submit_result_game_id_with_null_byte_returns_invalid   ... ok
+test tests::submit_result_game_id_with_space_returns_invalid       ... ok
+test tests::submit_result_game_id_with_slash_returns_invalid       ... ok
+test tests::submit_result_game_id_with_at_symbol_returns_invalid   ... ok
+test tests::submit_result_game_id_valid_charset_accepted           ... ok
+test tests::submit_result_game_id_single_char_accepted             ... ok
+test tests::submit_result_game_id_max_length_valid_charset_accepted ... ok
+```
+
+All pre-existing oracle tests must continue to pass.
+
+- [x] Tests added or updated
+- [ ] Manual testing performed
+
+## Contract Changes
+
+No new error codes. `InvalidGameId = 5` now covers three conditions (empty,
+over-length, invalid characters) instead of two, which is a strictly additive
+clarification.
+
+- [ ] ABI breaking? (requires re-deployment of existing contracts)
+- [ ] Storage migration needed?
+- [x] ABI reviewed for breaking changes
+
+> No ABI break. The error variant discriminant `5` is unchanged. Clients that
+> already handle `InvalidGameId` will handle the expanded condition correctly
+> without modification.
+
+## Security
+
+- [x] No secrets committed
+- [x] Security implications considered and documented
+
+This fix closes a fund-locking vector: a malicious or buggy oracle submission
+containing a non-printable character (e.g. a null byte injected via a crafted
+API response) would pass the old length check, get stored on-chain, and then
+permanently mismatch against the escrow's validated `game_id`, making the
+match unresolvable. The fix brings the oracle into parity with the escrow's
+existing character-set enforcement at the earliest possible point in the call.
+
+## Documentation
+
+- [ ] Relevant docs updated (docs/ folder, README, etc.)
+
+The `submit_result` doc comment in `lib.rs` and the `InvalidGameId` entry in
+`errors.rs` have been updated inline. No separate docs-folder changes are
+needed for this fix.

--- a/contracts/oracle/src/errors.rs
+++ b/contracts/oracle/src/errors.rs
@@ -15,7 +15,7 @@ use soroban_sdk::contracterror;
 /// |  2   | AlreadySubmitted   | A result has already been recorded for this match_id     |
 /// |  3   | ResultNotFound     | No result has been submitted for the given match_id      |
 /// |  4   | AlreadyInitialized | Contract has already been initialized                    |
-/// |  5   | InvalidGameId      | game_id is empty or exceeds the 64-byte maximum          |
+/// |  5   | InvalidGameId      | game_id is empty, exceeds 64 bytes, or contains chars outside [A-Za-z0-9_-] |
 /// |  6   | TransferFailed     | Token transfer in withdraw failed                        |
 /// |  7   | InvalidAmount      | withdraw amount must be greater than zero               |
 #[contracterror]
@@ -34,7 +34,9 @@ pub enum Error {
     /// [E004] `initialize` has already been called; the contract cannot be re-initialized.
     AlreadyInitialized = 4,
 
-    /// [E005] `game_id` is empty or exceeds the 64-byte maximum length.
+    /// [E005] `game_id` is empty, exceeds the 64-byte maximum length, or contains
+    /// characters outside the allowed set `[A-Za-z0-9_-]` (null bytes, control
+    /// characters, whitespace, non-ASCII sequences, etc.).
     InvalidGameId = 5,
 
     /// [E006] Token transfer failed during `withdraw`.

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -67,6 +67,31 @@ const MAX_GAME_ID_LEN: u32 = 64;
 /// Maximum number of entries returned by list_results in a single call.
 const MAX_LIST_LIMIT: u32 = 100;
 
+/// Validate that every byte of `game_id` belongs to the set `[A-Za-z0-9_-]`.
+///
+/// This enforces printable ASCII and prevents null bytes, control characters,
+/// whitespace, and non-ASCII sequences from entering persistent storage.
+/// The allowed set mirrors both the identifier format used by Lichess and
+/// Chess.com and the identical check performed by the escrow contract, ensuring
+/// the two contracts always agree on what constitutes a valid `game_id`.
+///
+/// The string is copied into a fixed 64-byte stack buffer — the same size as
+/// `MAX_GAME_ID_LEN` — so no heap allocation is required inside the WASM guest.
+fn is_valid_game_id(game_id: &String) -> bool {
+    let len = game_id.len() as usize;
+    // Safety: len is already validated to be in [1, MAX_GAME_ID_LEN].
+    let mut buf = [0u8; MAX_GAME_ID_LEN as usize];
+    game_id.copy_into_slice(&mut buf[..len]);
+    for i in 0..len {
+        let b = buf[i];
+        let ok = b.is_ascii_alphanumeric() || b == b'_' || b == b'-';
+        if !ok {
+            return false;
+        }
+    }
+    true
+}
+
 #[contract]
 pub struct OracleContract;
 
@@ -111,14 +136,16 @@ impl OracleContract {
     ///
     /// * `match_id` — The escrow match ID this result belongs to.
     /// * `game_id`  — The platform-specific game identifier (e.g. Lichess game ID). Must be
-    ///   non-empty and at most 64 bytes.
+    ///   non-empty, at most 64 bytes, and contain only `[A-Za-z0-9_-]` characters.
     /// * `result`   — The outcome: [`MatchResult::Player1Wins`], [`MatchResult::Player2Wins`],
     ///   or [`MatchResult::Draw`].
     ///
     /// # Errors
     ///
     /// * [`Error::Unauthorized`]     — Caller is not the registered admin.
-    /// * [`Error::InvalidGameId`]    — `game_id` is empty or exceeds 64 bytes.
+    /// * [`Error::InvalidGameId`]    — `game_id` is empty, exceeds 64 bytes, or contains
+    ///   characters outside `[A-Za-z0-9_-]` (null bytes, control characters, whitespace,
+    ///   non-ASCII sequences, etc.).
     /// * [`Error::AlreadySubmitted`] — A result already exists for this `match_id`.
     pub fn submit_result(
         env: Env,
@@ -135,6 +162,16 @@ impl OracleContract {
 
         let game_id_len = game_id.len();
         if game_id_len == 0 || game_id_len > MAX_GAME_ID_LEN {
+            return Err(Error::InvalidGameId);
+        }
+
+        // Enforce printable ASCII: only [A-Za-z0-9_-] are accepted.
+        // This mirrors the identical check in the escrow contract and closes the
+        // gap where a caller could submit a game_id containing null bytes, control
+        // characters, or non-ASCII sequences that would pass the length check but
+        // permanently diverge from the escrow's stored game_id, causing an
+        // irrecoverable GameIdMismatch that locks player funds.
+        if !is_valid_game_id(&game_id) {
             return Err(Error::InvalidGameId);
         }
 
@@ -762,6 +799,106 @@ mod tests {
             client.try_submit_result(&1u64, &long_game_id, &MatchResult::Player1Wins),
             Err(Ok(Error::InvalidGameId))
         ));
+    }
+
+    // ── Issue #1512: game_id character-set validation ─────────────────────────
+
+    #[test]
+    fn submit_result_game_id_with_null_byte_returns_invalid() {
+        let (env, contract_id) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        // Null byte — would brick the escrow match with GameIdMismatch if stored.
+        let bad_id = String::from_str(&env, "abc\x00def");
+        assert_eq!(
+            client.try_submit_result(&1u64, &bad_id, &MatchResult::Player1Wins),
+            Err(Ok(Error::InvalidGameId)),
+            "null byte in game_id must be rejected"
+        );
+    }
+
+    #[test]
+    fn submit_result_game_id_with_space_returns_invalid() {
+        let (env, contract_id) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        let bad_id = String::from_str(&env, "abc def");
+        assert_eq!(
+            client.try_submit_result(&1u64, &bad_id, &MatchResult::Player1Wins),
+            Err(Ok(Error::InvalidGameId)),
+            "space in game_id must be rejected"
+        );
+    }
+
+    #[test]
+    fn submit_result_game_id_with_slash_returns_invalid() {
+        let (env, contract_id) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        let bad_id = String::from_str(&env, "abc/def");
+        assert_eq!(
+            client.try_submit_result(&1u64, &bad_id, &MatchResult::Player1Wins),
+            Err(Ok(Error::InvalidGameId)),
+            "slash in game_id must be rejected"
+        );
+    }
+
+    #[test]
+    fn submit_result_game_id_with_at_symbol_returns_invalid() {
+        let (env, contract_id) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        let bad_id = String::from_str(&env, "abc@def");
+        assert_eq!(
+            client.try_submit_result(&1u64, &bad_id, &MatchResult::Player1Wins),
+            Err(Ok(Error::InvalidGameId)),
+            "@ in game_id must be rejected"
+        );
+    }
+
+    #[test]
+    fn submit_result_game_id_valid_charset_accepted() {
+        let (env, contract_id) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        // All allowed character classes: uppercase, lowercase, digits, underscore, hyphen.
+        let valid_id = String::from_str(&env, "AbcXyz-012_ABC");
+        assert!(
+            client
+                .try_submit_result(&1u64, &valid_id, &MatchResult::Player1Wins)
+                .is_ok(),
+            "valid [A-Za-z0-9_-] game_id must be accepted"
+        );
+    }
+
+    #[test]
+    fn submit_result_game_id_single_char_accepted() {
+        let (env, contract_id) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        // Minimum valid length: 1 byte from the allowed set.
+        let valid_id = String::from_str(&env, "a");
+        assert!(
+            client
+                .try_submit_result(&2u64, &valid_id, &MatchResult::Draw)
+                .is_ok(),
+            "single allowed char must be accepted"
+        );
+    }
+
+    #[test]
+    fn submit_result_game_id_max_length_valid_charset_accepted() {
+        let (env, contract_id) = setup();
+        let client = OracleContractClient::new(&env, &contract_id);
+
+        // 64 bytes of allowed characters — sits exactly on the length boundary.
+        let valid_id = String::from_str(&env, &"a".repeat(64));
+        assert!(
+            client
+                .try_submit_result(&3u64, &valid_id, &MatchResult::Player2Wins)
+                .is_ok(),
+            "64-char valid game_id must be accepted"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #1512 

# fix(oracle): validate game_id character set in submit_result

## Description

`oracle::submit_result` checked `game_id` length (1–64 bytes) but not its
character content. The escrow contract enforces `[A-Za-z0-9_-]` for `game_id`
on its side. If the oracle stored a `game_id` containing null bytes, control
characters, whitespace, or non-ASCII sequences, the stored `ResultEntry.game_id`
would permanently diverge from the escrow's accepted format, triggering an
irrecoverable `GameIdMismatch` error that locks player funds.

### Changes

**`contracts/oracle/src/lib.rs`**
- Added `is_valid_game_id` free function at module scope. It copies the string
  into a fixed 64-byte stack buffer (no heap allocation in the WASM guest) and
  checks every byte against `[A-Za-z0-9_-]`. The implementation is a verbatim
  mirror of the identical helper in the escrow contract, guaranteeing the two
  contracts always agree on what constitutes a valid `game_id`.
- `submit_result`: added the character-set check immediately after the length
  check. Both failures return `Error::InvalidGameId` — no new error code needed,
  and no ABI break.
- Updated `submit_result` doc comment to document the charset constraint and
  expand the `InvalidGameId` error description.
- Added 7 focused tests (see Testing section).

**`contracts/oracle/src/errors.rs`**
- Updated the `InvalidGameId = 5` table row and doc comment to describe the
  full validation rule: empty, over-length, _or_ characters outside
  `[A-Za-z0-9_-]`. No numeric code change — fully backwards compatible.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## Testing

Run the oracle test suite (requires Rust 1.88.0 — same toolchain as CI):

```bash
cargo test -p smile4money-oracle --lib --verbose
```

New tests to look for:

```
test tests::submit_result_game_id_with_null_byte_returns_invalid   ... ok
test tests::submit_result_game_id_with_space_returns_invalid       ... ok
test tests::submit_result_game_id_with_slash_returns_invalid       ... ok
test tests::submit_result_game_id_with_at_symbol_returns_invalid   ... ok
test tests::submit_result_game_id_valid_charset_accepted           ... ok
test tests::submit_result_game_id_single_char_accepted             ... ok
test tests::submit_result_game_id_max_length_valid_charset_accepted ... ok
```

All pre-existing oracle tests must continue to pass.

- [x] Tests added or updated
- [ ] Manual testing performed

## Contract Changes

No new error codes. `InvalidGameId = 5` now covers three conditions (empty,
over-length, invalid characters) instead of two, which is a strictly additive
clarification.

- [ ] ABI breaking? (requires re-deployment of existing contracts)
- [ ] Storage migration needed?
- [x] ABI reviewed for breaking changes

> No ABI break. The error variant discriminant `5` is unchanged. Clients that
> already handle `InvalidGameId` will handle the expanded condition correctly
> without modification.

## Security

- [x] No secrets committed
- [x] Security implications considered and documented

This fix closes a fund-locking vector: a malicious or buggy oracle submission
containing a non-printable character (e.g. a null byte injected via a crafted
API response) would pass the old length check, get stored on-chain, and then
permanently mismatch against the escrow's validated `game_id`, making the
match unresolvable. The fix brings the oracle into parity with the escrow's
existing character-set enforcement at the earliest possible point in the call.

## Documentation

- [ ] Relevant docs updated (docs/ folder, README, etc.)

The `submit_result` doc comment in `lib.rs` and the `InvalidGameId` entry in
`errors.rs` have been updated inline. No separate docs-folder changes are
needed for this fix.
