### PR TITLE
fix(auth): refuse to start in production without a strong JWT_SECRET

### DIFF
--- a/apps/backend/src/middleware/auth.ts
+++ b/apps/backend/src/middleware/auth.ts
@@ -7,13 +7,17 @@ import jwt, { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
  * If not set, defaults to 'test-secret' for development only.
  * NEVER use default in production.
  */
-const SECRET = process.env.JWT_SECRET || 'test-secret';
+const DEFAULT_SECRET = 'test-secret';
+const SECRET = process.env.JWT_SECRET || DEFAULT_SECRET;
 
-// Check if we're in production without a proper secret
-if (process.env.NODE_ENV === 'production' && SECRET === 'test-secret') {
-  console.warn(
-    'WARNING: JWT_SECRET is not set in production. This is a security vulnerability. ' +
-      'Set JWT_SECRET to a strong random string in your environment variables.',
+// Hard fail at startup in production: a missing or default JWT_SECRET lets
+// anyone forge tokens with the well-known default, so refusing to start is
+// the only safe behavior. The default is only acceptable for local development.
+if (process.env.NODE_ENV === 'production' && SECRET === DEFAULT_SECRET) {
+  throw new Error(
+    'JWT_SECRET is not set (or is set to the known default "test-secret"). ' +
+      'Refusing to start in production. Set JWT_SECRET to a strong, random ' +
+      'string in your environment variables.',
   );
 }
 


### PR DESCRIPTION
Closes #1520
Closes #1521
Closes #1522
Closes #1523

## Description

**Problem:** When `JWT_SECRET` is not set, `apps/backend/src/middleware/auth.ts` falls back to the literal string `test-secret` as the JWT signing key and only emits a `console.warn` — even in production. Because the default is visible in the source, any attacker who knows it can forge valid JWTs for any Stellar address and bypass authentication entirely, enabling fraudulent match creation and false oracle submissions.

**Fix:** In production (`NODE_ENV === 'production'`), the module now throws a hard error at startup when `JWT_SECRET` is unset or equals the known default, refusing to boot the server. Because `auth.ts` is imported by the route handlers at server start, the error aborts startup before the server can listen. The `test-secret` fallback remains unchanged for non-production (local development).

**Expected behaviour after merge:** A production deployment without a strong, explicitly set `JWT_SECRET` fails fast with a clear error message instead of silently running with a forgeable signing key.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## Testing

- [ ] Tests added or updated
- [x] Manual testing performed

Verified with a temporary vitest harness that imports the module fresh under different environments (harness removed after verification):

| Environment | Result |
|---|---|
| `NODE_ENV=production`, `JWT_SECRET` unset | Startup throws with a `JWT_SECRET` error message |
| `NODE_ENV=production`, `JWT_SECRET=test-secret` | Startup throws |
| `NODE_ENV=production`, strong random `JWT_SECRET` | Module loads normally |
| `NODE_ENV=development`, `JWT_SECRET` unset | Module loads normally (dev fallback preserved) |

Additional checks:

- `tsc --noEmit` reports no new errors from this change (the only errors are pre-existing parse errors in `tests/queue.test.ts`, untouched by this PR).
- Full backend test suite results are identical before/after the change (42 failed / 160 passed — pre-existing environment-related failures, e.g. uninitialized queue store, unrelated to auth).

## Contract Changes

- [ ] ABI breaking? (requires re-deployment of existing contracts)
- [ ] Storage migration needed?
- [ ] ABI reviewed for breaking changes

No contract changes — backend middleware only.

## Security

- [x] No secrets committed
- [x] Security implications considered and documented

Closes a token-forgery vulnerability: the well-known default signing key can no longer be used in production, and a misconfigured deployment now fails fast rather than running with a forgeable secret. Production environments must set a strong random `JWT_SECRET` (see `AUTHENTICATION_AND_RATE_LIMITING.md` for guidance).

## Documentation

- [ ] Relevant docs updated (docs/ folder, README, etc.)