### PR TITLE
fix(matches): reject fractional stakeAmount with 400 error

### DIFF
--- a/apps/backend/src/routes/matches.ts
+++ b/apps/backend/src/routes/matches.ts
@@ -78,8 +78,8 @@ router.post('/', async (req, res) => {
   if (!player2 || typeof player2 !== 'string') {
     return res.status(400).json({ error: 'player2 is required' });
   }
-  if (typeof stakeAmount !== 'number' || !Number.isFinite(stakeAmount)) {
-    return res.status(400).json({ error: 'stakeAmount must be a number' });
+  if (typeof stakeAmount !== 'number' || !Number.isFinite(stakeAmount) || !Number.isInteger(stakeAmount)) {
+    return res.status(400).json({ error: 'stakeAmount must be a whole number of stroops' });
   }
   if (stakeAmount <= 0 || stakeAmount > Number.MAX_SAFE_INTEGER) {
     return res.status(400).json({ error: 'stakeAmount must be a valid, positive amount' });

--- a/apps/backend/tests/matches.test.ts
+++ b/apps/backend/tests/matches.test.ts
@@ -126,6 +126,16 @@ describe('POST /api/matches', () => {
     expect(response.status).toBe(400);
   });
 
+  it('returns 400 when stakeAmount is not a whole number', async () => {
+    mockLichessGameFound('lichess-game-abc123');
+    const response = await request(app)
+      .post('/api/matches')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ player2: 'GPLAYER2BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB', stakeAmount: 1.5, token: 'XLM', gameId: 'lichess-game-abc123', platform: 'lichess' });
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('stakeAmount must be a whole number of stroops');
+  });
+
   it('returns 400 when gameId is missing', async () => {
     const response = await request(app)
       .post('/api/matches')


### PR DESCRIPTION
Closes #1531
Closes #1532
Closes #1533
Closes #1534

## Summary

`POST /api/matches` validated `stakeAmount` with `typeof stakeAmount !== 'number'` and `!Number.isFinite(stakeAmount)`, but not integer-ness. A caller could pass a value like `1.5` and pass API validation. Because the on-chain contract requires `stake_amount` as a **whole-number `i128` (stroops)**, a fractional value later surfaces as a confusing transaction error on the blockchain.

## Change

Added `!Number.isInteger(stakeAmount)` to the `stakeAmount` validation so non-integer values return a clear `400`:

```ts
if (typeof stakeAmount !== 'number' || !Number.isFinite(stakeAmount) || !Number.isInteger(stakeAmount)) {
  return res.status(400).json({ error: 'stakeAmount must be a whole number of stroops' });
}
```

## Tests

Added a test asserting that `stakeAmount: 1.5` returns `400` with the message `stakeAmount must be a whole number of stroops`. The new test passes.

> Note: 4 pre-existing tests in `matches.test.ts` and typecheck errors in `tests/queue.test.ts` fail on `master` independent of this change (confirmed via `git stash`).