### PR TITLE
fix(frontend): fetch match details from EscrowContract.get_match via RPC- #1

### DIFF
--- a/apps/frontend/src/components/DepositStake.tsx
+++ b/apps/frontend/src/components/DepositStake.tsx
@@ -1,5 +1,15 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Networks, rpc } from '@stellar/stellar-sdk';
+import {
+  Account,
+  Asset,
+  Networks,
+  Operation,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc,
+  scValToNative,
+} from '@stellar/stellar-sdk';
+import type { xdr } from '@stellar/stellar-sdk';
 
 type DepositStatus = 'idle' | 'loading' | 'pending' | 'success' | 'error' | 'approving';
 type AllowanceStatus = 'unknown' | 'checking' | 'sufficient' | 'insufficient';
@@ -11,6 +21,88 @@ interface MatchDetails {
   player2: string;
   player1Deposited: boolean;
   player2Deposited: boolean;
+}
+
+/**
+ * Fetch a match record from the deployed EscrowContract via Soroban RPC and
+ * map it to the shape the UI renders.
+ *
+ * `get_match` is a read-only view, so we simulate the invocation — no wallet
+ * signature or transaction submission is required. The simulation source only
+ * needs to exist as an account on the ledger; the deployed contract address is
+ * used so this works even before the user connects a wallet.
+ */
+async function fetchMatchFromEscrow({
+  matchId,
+  contractId,
+  rpcUrl,
+  networkPassphrase,
+}: {
+  matchId: string;
+  contractId: string;
+  rpcUrl: string;
+  networkPassphrase: string;
+}): Promise<MatchDetails> {
+  if (!/^\d+$/.test(matchId)) {
+    throw new Error('Invalid match ID');
+  }
+
+  const server = new rpc.Server(rpcUrl);
+  const source = new Account(contractId, '0');
+
+  const tx = new TransactionBuilder(source, {
+    fee: '100',
+    networkPassphrase,
+  })
+    .addOperation(
+      Operation.invokeContractFunction({
+        contract: contractId,
+        function: 'get_match',
+        args: [nativeToScVal(BigInt(matchId), { type: 'u64' })],
+      }),
+    )
+    .setTimeout(30)
+    .build();
+
+  const sim = await server.simulateTransaction(tx);
+
+  if ('error' in sim) {
+    throw new Error(
+      `Could not load match ${matchId}: the escrow contract returned an error (${sim.error})`,
+    );
+  }
+  if (!sim.result?.retval) {
+    throw new Error(`Could not load match ${matchId}: the RPC server returned no result`);
+  }
+
+  return deserializeMatch(sim.result.retval, networkPassphrase);
+}
+
+/** Convert the ScVal returned by `get_match` into the UI's MatchDetails shape. */
+function deserializeMatch(returnValue: xdr.ScVal, networkPassphrase: string): MatchDetails {
+  const raw = (scValToNative(returnValue) ?? {}) as Record<string, unknown>;
+
+  if (
+    (typeof raw.stake_amount !== 'bigint' && typeof raw.stake_amount !== 'number') ||
+    typeof raw.player1 !== 'string' ||
+    typeof raw.player2 !== 'string'
+  ) {
+    throw new Error('Unexpected response from EscrowContract.get_match');
+  }
+
+  const tokenAddress = typeof raw.token === 'string' ? raw.token : '';
+  // The contract stores the native XLM asset as its Soroban contract address;
+  // map it back to the symbol the UI already understands.
+  const nativeTokenAddress = Asset.native().contractId(networkPassphrase);
+
+  return {
+    stakeAmount: String(raw.stake_amount),
+    token: tokenAddress === nativeTokenAddress ? 'xlm' : tokenAddress,
+    player1: raw.player1,
+    player2: raw.player2,
+    player1Deposited: Boolean(raw.player1_deposited),
+    player2Deposited: Boolean(raw.player2_deposited),
+  };
 }
 
 interface DepositStakeProps {
@@ -55,23 +147,19 @@ export function DepositStake({
 
     setStatus('loading');
     try {
-      // In a real implementation, this would call the contract's get_match function
-      // For now, we simulate with mock data
-      const mockDetails: MatchDetails = {
-        stakeAmount: '100',
-        token: 'xlm',
-        player1: 'GPLAYER1...',
-        player2: 'GPLAYER2...',
-        player1Deposited: false,
-        player2Deposited: false,
-      };
-      setMatchDetails(mockDetails);
+      const details = await fetchMatchFromEscrow({
+        matchId,
+        contractId,
+        rpcUrl,
+        networkPassphrase,
+      });
+      setMatchDetails(details);
       setStatus('idle');
     } catch (err) {
       setStatus('error');
       setErrorMsg(err instanceof Error ? err.message : 'Failed to fetch match details');
     }
-  }, [matchId, contractId]);
+  }, [matchId, contractId, rpcUrl, networkPassphrase]);
 
   useEffect(() => {
     fetchMatchDetails();
@@ -152,7 +240,8 @@ export function DepositStake({
   // player already deposited, allowance is still being checked, or allowance is
   // insufficient. The isPending guard is the critical one — without it the user
   // can click twice and submit duplicate transactions.
-  const isDisabled = isLoading || isPending || hasDeposited(matchDetails) || isCheckingAllowance || needsApproval;
+  const isDisabled =
+    isLoading || isPending || hasDeposited(matchDetails) || isCheckingAllowance || needsApproval;
 
   // Loading state
   if (isLoading && !matchDetails) {

--- a/apps/frontend/tests/DepositStake.test.tsx
+++ b/apps/frontend/tests/DepositStake.test.tsx
@@ -1,26 +1,78 @@
 import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DepositStake } from '../src/components/DepositStake';
 
-// Mock @stellar/stellar-sdk
+// Mutable state shared between the test body and the @stellar/stellar-sdk mock.
+// vi.mock is hoisted above imports, so the mock can only close over values
+// created with vi.hoisted().
+const { defaultMatch, setSimulateResponse, getSimulateResponse } = vi.hoisted(() => {
+  const defaultMatch = {
+    id: 0n,
+    player1: 'GABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF123456',
+    player2: 'G1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB',
+    stake_amount: 10000000n,
+    // Matches the value returned by the mocked Asset.native().contractId()
+    token: 'NATIVE-XLM-TOKEN',
+    game_id: 'lichess_abc123',
+    platform: 'Lichess',
+    state: 'Pending',
+    player1_deposited: false,
+    player2_deposited: false,
+  };
+
+  let simulateResponse: unknown = { result: { retval: defaultMatch } };
+
+  return {
+    defaultMatch,
+    setSimulateResponse: (response: unknown) => {
+      simulateResponse = response;
+    },
+    getSimulateResponse: () => simulateResponse,
+  };
+});
+
+// Mock @stellar/stellar-sdk so DepositStake's read-only get_match simulation
+// can run without a live Soroban RPC server.
 vi.mock('@stellar/stellar-sdk', () => ({
   Networks: {
     TESTNET: 'Test SDF Network ; September 2015',
     PUBLIC: 'Public Global Stellar Network ; September 2015',
   },
-  SorobanRpc: {
+  rpc: {
     Server: vi.fn().mockImplementation(() => ({
-      sendTransaction: vi.fn(),
-      getTransaction: vi.fn(),
+      simulateTransaction: vi.fn().mockImplementation(async () => getSimulateResponse()),
     })),
-    GetTransactionStatus: {
-      PENDING: 'PENDING',
-      SUCCESS: 'SUCCESS',
-      ERROR: 'ERROR',
-    },
+  },
+  Account: class Account {
+    constructor(_accountId: string, _sequence: string) {}
+  },
+  Operation: {
+    invokeContractFunction: vi.fn((opts) => opts),
+  },
+  TransactionBuilder: class TransactionBuilder {
+    addOperation() {
+      return this;
+    }
+    setTimeout() {
+      return this;
+    }
+    build() {
+      return {};
+    }
+  },
+  nativeToScVal: vi.fn((value) => value),
+  scValToNative: vi.fn((value) => value),
+  Asset: {
+    native: () => ({
+      contractId: () => 'NATIVE-XLM-TOKEN',
+    }),
   },
 }));
+
+beforeEach(() => {
+  setSimulateResponse({ result: { retval: defaultMatch } });
+});
 
 describe('DepositStake — loading state', () => {
   it('shows loading state initially while fetching match details', () => {
@@ -39,13 +91,88 @@ describe('DepositStake — no match ID', () => {
 });
 
 describe('DepositStake — match info display', () => {
-  it('displays match stake amount after mock data loads', async () => {
+  it('displays match details fetched from the escrow contract', async () => {
     render(<DepositStake matchId="123" playerAddress="GABCDEF123456" contractId="test-contract" />);
 
-    // Wait for the mock data to be loaded
-    await waitFor(() => {
-      expect(screen.getByTestId('match-info')).toBeInTheDocument();
+    await screen.findByTestId('match-info');
+
+    // On-chain stake amount (stroops) and the native token symbol
+    expect(screen.getByText('10000000')).toBeInTheDocument();
+    expect(screen.getByText('XLM')).toBeInTheDocument();
+
+    // Player addresses are truncated for display
+    expect(screen.getByText('GABC...3456')).toBeInTheDocument();
+    expect(screen.getByText('G123...90AB')).toBeInTheDocument();
+
+    expect(screen.getByTestId('player1-status')).toHaveTextContent('Pending');
+    expect(screen.getByTestId('player2-status')).toHaveTextContent('Pending');
+  });
+
+  it('renders the raw token address when the token is not native XLM', async () => {
+    setSimulateResponse({
+      result: {
+        retval: {
+          ...defaultMatch,
+          token: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+        },
+      },
     });
+
+    render(<DepositStake matchId="123" playerAddress="GABCDEF123456" contractId="test-contract" />);
+
+    await screen.findByTestId('match-info');
+    expect(
+      screen.getByText('CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows deposited indicators when on-chain data reports a deposit', async () => {
+    setSimulateResponse({
+      result: {
+        retval: { ...defaultMatch, player1_deposited: true },
+      },
+    });
+
+    render(<DepositStake matchId="123" playerAddress="GABCDEF123456" contractId="test-contract" />);
+
+    await screen.findByTestId('match-info');
+    expect(screen.getByTestId('player1-status')).toHaveTextContent('✓ Deposited');
+    expect(screen.getByTestId('player2-status')).toHaveTextContent('Pending');
+
+    // Already deposited — deposit button is disabled and relabelled
+    expect(screen.getByTestId('deposit-btn')).toBeDisabled();
+    expect(screen.getByTestId('deposit-btn')).toHaveTextContent('Already Deposited');
+  });
+});
+
+describe('DepositStake — RPC error handling', () => {
+  it('shows an error and a retry button when get_match returns an error', async () => {
+    setSimulateResponse({ error: 'HostError' });
+
+    render(<DepositStake matchId="999" playerAddress="GABCDEF123456" contractId="test-contract" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('deposit-error')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Could not load match 999/)).toBeInTheDocument();
+    expect(screen.getByTestId('retry-btn')).toBeInTheDocument();
+  });
+
+  it('recovers via the retry button when the RPC call later succeeds', async () => {
+    setSimulateResponse({ error: 'HostError' });
+
+    render(<DepositStake matchId="123" playerAddress="GABCDEF123456" contractId="test-contract" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('deposit-error')).toBeInTheDocument();
+    });
+
+    // The match now exists on-chain — retrying loads it
+    setSimulateResponse({ result: { retval: defaultMatch } });
+    fireEvent.click(screen.getByTestId('retry-btn'));
+
+    await screen.findByTestId('match-info');
+    expect(screen.getByText('10000000')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
Closes #1524
Closes #1525
Closes #1527
Closes #1526




## Description

`DepositStake` populated its match info from a **hardcoded mock object** (`stakeAmount: '100'`, `player1: 'GPLAYER1...'`, ...). Every user saw identical fake data regardless of which match ID was passed, so the component was non-functional in production — it never read anything from the chain.

This PR replaces the mock with a real, read-only Soroban RPC call to `EscrowContract.get_match(match_id)` using `@stellar/stellar-sdk`:

- Builds an `invokeContractFunction` operation (`get_match`, arg serialized as `u64`) in a `TransactionBuilder`, then simulates it via `rpc.Server.simulateTransaction`.
- No wallet signature or submitted transaction is required — `get_match` is a view function. The simulation source uses the deployed contract's own address, so the component works even before a wallet is connected.
- Deserializes the returned `ScVal` with `scValToNative` and populates `matchDetails` from the actual on-chain record: `stake_amount`, `player1`, `player2`, `player1_deposited`, `player2_deposited`.
- The native XLM token address (computed per-network via `Asset.native().contractId(networkPassphrase)`) maps back to the `xlm` symbol the UI already understands; other tokens render as their raw address.
- Contract errors (e.g. `MatchNotFound` → `HostError`) and empty RPC results surface through the existing error + Retry UI.

**Expected behaviour after merge:** the stake amount, both player addresses, and deposit status shown in the deposit panel come from on-chain state for the actual match ID.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update

## Testing

- [x] Tests added or updated
- [ ] Manual testing performed

Verification performed:

- `npx tsc --noEmit` — no errors in the changed files (remaining errors are pre-existing in `src/App.tsx`, `src/components/Toast.tsx`, `src/components/forms/RegistrationForm.tsx`, untouched by this PR).
- `npx vitest run` — **128 passed, 1 skipped** (pre-existing skip). The `DepositStake` suite (11 tests) covers the real RPC path: on-chain stake/token/player rendering, non-native token address display, deposited-status indicators (button disabled + "Already Deposited"), RPC error state, and retry recovery.
- `npx vite build` — succeeds.
- Prettier — clean.

### Test changes

The `@stellar/stellar-sdk` mock was rewritten to exercise the real simulation path (`rpc.Server.simulateTransaction`, `TransactionBuilder`, `Operation`, `nativeToScVal`, `scValToNative`, `Asset`) with a controllable response, replacing the old `SorobanRpc` mock that the component never used.

## Contract Changes

No smart-contract changes — this PR is frontend-only.

- [ ] ABI breaking? (requires re-deployment of existing contracts)
- [ ] Storage migration needed?
- [ ] ABI reviewed for breaking changes

## Security

- [x] No secrets committed
- [x] Security implications considered and documented

No secrets. Read-only contract invocation — the change only *reads* match state and never builds a signature or submits a transaction. No wallet signing flow is touched.

## Documentation

- [ ] Relevant docs updated (docs/ folder, README, etc.)

No docs change required; `docs/api-reference.md` already documents `get_match` and its return shape, which this implementation follows.