### PR TITLE
fix(frontend): check only the acting player's deposit flag in DepositStake

### DIFF
--- a/apps/frontend/src/components/DepositStake.tsx
+++ b/apps/frontend/src/components/DepositStake.tsx
@@ -47,7 +47,16 @@ export function DepositStake({
 
   const hasDeposited = (matchDetails: MatchDetails | null): boolean => {
     if (!matchDetails || !playerAddress) return false;
-    return matchDetails.player1Deposited || matchDetails.player2Deposited;
+    // Identify which player is acting by comparing against the stored addresses,
+    // then check only that player's deposit flag. Otherwise a player's deposit
+    // would incorrectly disable the other player's deposit button.
+    if (matchDetails.player1 === playerAddress) {
+      return matchDetails.player1Deposited;
+    }
+    if (matchDetails.player2 === playerAddress) {
+      return matchDetails.player2Deposited;
+    }
+    return false;
   };
 
   const fetchMatchDetails = useCallback(async () => {


### PR DESCRIPTION
Closes #1528
Closes #1529
Closes #1530
Closes #1541


## Description

Fixes a bug in the frontend `DepositStake` component where `hasDeposited` returned `matchDetails.player1Deposited || matchDetails.player2Deposited`.

Because the check used a logical OR across **both** deposit flags, as soon as **player 1** deposited, `hasDeposited` became `true` for **everyone** — including player 2. Player 2's deposit button was disabled and labelled **"Already Deposited"**, making it impossible for player 2 to fund the match.

### Root cause

```ts
// Before — OR across both players, so one player's deposit blocks the other
return matchDetails.player1Deposited || matchDetails.player2Deposited;
```

### Expected behaviour

Identify which player is acting by comparing the connected wallet address against the stored `player1`/`player2` addresses, then check **only that player's** deposit flag.

## Changes

- Updated `hasDeposited` in `apps/frontend/src/components/DepositStake.tsx`:
  - If `playerAddress` matches `player1` → return `player1Deposited`.
  - If `playerAddress` matches `player2` → return `player2Deposited`.
  - Otherwise → `false` (the acting address isn't a known player).
- Added a clarifying comment explaining why the per-player check matters.

```ts
// After
if (matchDetails.player1 === playerAddress) {
  return matchDetails.player1Deposited;
}
if (matchDetails.player2 === playerAddress) {
  return matchDetails.player2Deposited;
}
return false;
```

## Testing

- `DepositStake.test.tsx`: all 7 existing tests pass.
- Full frontend suite: **124 passed, 1 skipped**.
- `DepositStake.tsx` introduces no new TypeScript errors (pre-existing unrelated type errors elsewhere in the repo are unaffected).

## Impact

Players 1 and 2 can now deposit independently, matching on-chain behaviour where each player deposits their own stake. The match only activates once both deposits are in.