### PR TITLE
fix(rate-limit): only trust X-Forwarded-For from trusted proxies

### DIFF
--- a/AUTHENTICATION_AND_RATE_LIMITING.md
+++ b/AUTHENTICATION_AND_RATE_LIMITING.md
@@ -91,7 +91,7 @@ The validate-game endpoint is rate-limited to prevent abuse by unauthenticated u
 
 - **Limit**: 100 requests per 60 seconds per IP address
 - **Algorithm**: Token bucket with automatic refill
-- **IP Detection**: Respects `X-Forwarded-For` header for proxied requests
+- **IP Detection**: Uses the direct connection IP. The `X-Forwarded-For` header is only honored when the request arrives from a proxy listed in the middleware's `trustedProxies` option (e.g. your own reverse proxy); by default the header is ignored so clients cannot spoof it to bypass rate limiting.
 
 #### Rate Limit Headers
 

--- a/apps/backend/dist/src/middleware/rate-limit.js
+++ b/apps/backend/dist/src/middleware/rate-limit.js
@@ -88,7 +88,8 @@ export class RateLimitStore {
  * ```
  */
 export function createRateLimitMiddleware(store, options) {
-    const keyExtractor = options?.keyExtractor || ((req) => getClientIp(req));
+    const trustedProxies = options?.trustedProxies || [];
+    const keyExtractor = options?.keyExtractor || ((req) => getClientIp(req, trustedProxies));
     const statusCode = options?.statusCode || 429;
     const message = options?.message || 'Too many requests, please try again later';
     return (req, res, next) => {
@@ -109,13 +110,19 @@ export function createRateLimitMiddleware(store, options) {
 }
 /**
  * Extract the client's IP address from the request.
- * Considers X-Forwarded-For header for proxied requests.
+ *
+ * The X-Forwarded-For header is only honored when the request arrives directly
+ * from a trusted proxy; otherwise a client could spoof the header to cycle
+ * through fake IPs and bypass per-IP rate limiting.
  */
-function getClientIp(req) {
-    const forwarded = req.header('X-Forwarded-For');
-    if (forwarded) {
-        // X-Forwarded-For can be a comma-separated list; take the first IP
-        return forwarded.split(',')[0].trim();
+function getClientIp(req, trustedProxies) {
+    const remoteAddress = req.socket.remoteAddress || 'unknown';
+    if (trustedProxies.includes(remoteAddress)) {
+        const forwarded = req.header('X-Forwarded-For');
+        if (forwarded) {
+            // X-Forwarded-For can be a comma-separated list; take the first IP (the original client)
+            return forwarded.split(',')[0].trim();
+        }
     }
-    return req.socket.remoteAddress || 'unknown';
+    return remoteAddress;
 }

--- a/apps/backend/src/middleware/rate-limit.ts
+++ b/apps/backend/src/middleware/rate-limit.ts
@@ -117,6 +117,22 @@ export class RateLimitStore {
   }
 }
 
+interface RateLimitMiddlewareOptions {
+  keyExtractor?: (req: Request) => string;
+  statusCode?: number;
+  message?: string;
+  /**
+   * IP addresses of proxies that this server trusts to set the X-Forwarded-For
+   * header (e.g. a reverse proxy like nginx or a load balancer).
+   *
+   * The X-Forwarded-For header is only honored when the request's direct
+   * connection peer (req.socket.remoteAddress) is in this list. Defaults to an
+   * empty list, meaning the header is never trusted and the direct connection
+   * IP is used for rate limiting.
+   */
+  trustedProxies?: string[];
+}
+
 /**
  * Express middleware factory for rate limiting by IP address.
  *
@@ -127,14 +143,15 @@ export class RateLimitStore {
  * Example usage:
  * ```
  * const limiter = new RateLimitStore(100, 60000, 100); // 100 req/min
- * router.use(createRateLimitMiddleware(limiter));
+ * router.use(createRateLimitMiddleware(limiter, { trustedProxies: ['127.0.0.1'] }));
  * ```
  */
 export function createRateLimitMiddleware(
   store: RateLimitStore,
-  options?: { keyExtractor?: (req: Request) => string; statusCode?: number; message?: string },
+  options?: RateLimitMiddlewareOptions,
 ) {
-  const keyExtractor = options?.keyExtractor || ((req: Request) => getClientIp(req));
+  const trustedProxies = options?.trustedProxies || [];
+  const keyExtractor = options?.keyExtractor || ((req: Request) => getClientIp(req, trustedProxies));
   const statusCode = options?.statusCode || 429;
   const message = options?.message || 'Too many requests, please try again later';
 
@@ -165,13 +182,21 @@ export function createRateLimitMiddleware(
 
 /**
  * Extract the client's IP address from the request.
- * Considers X-Forwarded-For header for proxied requests.
+ *
+ * The X-Forwarded-For header is only honored when the request arrives directly
+ * from a trusted proxy; otherwise a client could spoof the header to cycle
+ * through fake IPs and bypass per-IP rate limiting.
  */
-function getClientIp(req: Request): string {
-  const forwarded = req.header('X-Forwarded-For');
-  if (forwarded) {
-    // X-Forwarded-For can be a comma-separated list; take the first IP
-    return forwarded.split(',')[0].trim();
+function getClientIp(req: Request, trustedProxies: string[]): string {
+  const remoteAddress = req.socket.remoteAddress || 'unknown';
+
+  if (trustedProxies.includes(remoteAddress)) {
+    const forwarded = req.header('X-Forwarded-For');
+    if (forwarded) {
+      // X-Forwarded-For can be a comma-separated list; take the first IP (the original client)
+      return forwarded.split(',')[0].trim();
+    }
   }
-  return req.socket.remoteAddress || 'unknown';
+
+  return remoteAddress;
 }

--- a/apps/backend/tests/rate-limit-middleware.test.ts
+++ b/apps/backend/tests/rate-limit-middleware.test.ts
@@ -1,0 +1,64 @@
+import request from 'supertest';
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import { RateLimitStore, createRateLimitMiddleware } from '../src/middleware/rate-limit.js';
+
+const createApp = (options?: { trustedProxies?: string[]; capacity?: number }) => {
+  const store = new RateLimitStore(options?.capacity ?? 100, 60 * 1000, 100);
+  const app = express();
+  app.use(createRateLimitMiddleware(store, options));
+  app.get('/', (_req, res) => res.json({ ok: true }));
+  return app;
+};
+
+/** Discover the direct connection IP supertest uses when hitting the app. */
+const getRemoteAddress = async (): Promise<string> => {
+  const app = express();
+  app.get('/', (_req, res) => res.json({ ip: _req.socket.remoteAddress }));
+  const response = await request(app).get('/');
+  return response.body.ip as string;
+};
+
+describe('createRateLimitMiddleware client IP detection', () => {
+  it('ignores X-Forwarded-For by default and buckets by direct connection IP', async () => {
+    const app = createApp({ capacity: 2 });
+
+    // All requests share the same bucket because the spoofed
+    // X-Forwarded-For headers are ignored and the direct connection IP is used.
+    const r1 = await request(app).get('/').set('X-Forwarded-For', '1.2.3.4');
+    const r2 = await request(app).get('/').set('X-Forwarded-For', '5.6.7.8');
+    const r3 = await request(app).get('/').set('X-Forwarded-For', '9.9.9.9');
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    // Third request hits the 2-token bucket for the shared direct IP
+    expect(r3.status).toBe(429);
+  });
+
+  it('honors X-Forwarded-For when the connection arrives from a trusted proxy', async () => {
+    const remoteAddress = await getRemoteAddress();
+    const app = createApp({ trustedProxies: [remoteAddress], capacity: 2 });
+
+    // Two distinct client IPs get separate buckets of 2 tokens each.
+    const r1 = await request(app).get('/').set('X-Forwarded-For', '1.2.3.4');
+    const r2 = await request(app).get('/').set('X-Forwarded-For', '5.6.7.8');
+    const r3 = await request(app).get('/').set('X-Forwarded-For', '5.6.7.8');
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(r3.status).toBe(200); // still within 5.6.7.8's own bucket
+  });
+
+  it('uses the direct connection IP when a trusted proxy sends no X-Forwarded-For', async () => {
+    const remoteAddress = await getRemoteAddress();
+    const app = createApp({ trustedProxies: [remoteAddress], capacity: 2 });
+
+    const r1 = await request(app).get('/');
+    const r2 = await request(app).get('/');
+    const r3 = await request(app).get('/');
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(r3.status).toBe(429);
+  });
+});


### PR DESCRIPTION
Closes #1537
Closes #1538
Closes #1539
Closes #1540

## Summary

`getClientIp` in the rate-limit middleware read the **first entry of `X-Forwarded-For` unconditionally**. Because that header is client-controlled, anyone could spoof it and cycle through fake IPs to bypass per-IP rate limiting entirely — defeating the rate limiter's purpose.

This PR makes the middleware trust `X-Forwarded-For` **only when the request arrives directly from a known proxy**.

## Changes

- **`apps/backend/src/middleware/rate-limit.ts`**
  - Added a `trustedProxies?: string[]` option to `createRateLimitMiddleware`, defaulting to an empty list (direct client IP only).
  - `getClientIp` now honors `X-Forwarded-For` only when `req.socket.remoteAddress` (the direct connection peer) is in `trustedProxies`; otherwise it buckets by the direct connection IP, so spoofed headers are ignored.
- **`apps/backend/dist/src/middleware/rate-limit.js`** — mirrored the change in the committed compiled output.
- **`apps/backend/tests/rate-limit-middleware.test.ts`** (new) — covers:
  1. Default config: spoofed `X-Forwarded-For` headers share one bucket and hit the limit (429).
  2. Trusted proxy configured: different `X-Forwarded-For` clients get separate buckets.
  3. Trusted proxy with no header: falls back to the direct connection IP.
- **`AUTHENTICATION_AND_RATE_LIMITING.md`** — documented the new IP-detection behavior.

## Verification

- `npx vitest run tests/rate-limit-middleware.test.ts tests/validate-game.test.ts` → 22/22 pass.
- Full backend suite shows **no regressions**: the same 8 failing files / 42 failing tests exist on the pre-change tree (pre-existing issues, e.g. `oracle-submit` queue initialization).
- `tsc --noEmit` compiles the changed files cleanly; the only errors are pre-existing syntax errors in `tests/queue.test.ts`.

## Deployment note

The `validate-game` route uses the default (no `trustedProxies`), so `X-Forwarded-For` is now always ignored there. If the backend sits behind a reverse proxy (nginx, ELB, etc.), pass its IP when constructing the middleware, e.g.:

```ts
createRateLimitMiddleware(rateLimitStore, { trustedProxies: ['<proxy-ip>'] })
```