### PR TITLE
fix: harden escrow result handling and registry TTL

### DIFF
--- a/contracts/contract-registry/src/lib.rs
+++ b/contracts/contract-registry/src/lib.rs
@@ -44,6 +44,11 @@ pub struct ContractRegistry;
 const REGISTRATION_TTL_LEDGERS: u32 = 100_000;
 const REGISTRATION_TTL_BUMP: u32 = 50_000;
 
+/// Instance-storage TTL threshold.
+const INSTANCE_LIFETIME_THRESHOLD: u32 = 518_400;
+/// Instance-storage TTL bump amount.
+const INSTANCE_BUMP_AMOUNT: u32 = 518_400;
+
 #[contractimpl]
 impl ContractRegistry {
     pub fn initialize(env: Env, admin: Address, max_events: u32) -> Result<(), Error> {
@@ -60,6 +65,9 @@ impl ContractRegistry {
             .set(&DataKey::RegistrationCount, &0u32);
         env.storage().instance().set(&DataKey::Events, &Vec::<Symbol>::new(&env));
 
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         Ok(())
     }
 
@@ -70,6 +78,9 @@ impl ContractRegistry {
         }
         caller.require_auth();
         env.storage().instance().set(&DataKey::Paused, &true);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         Ok(())
     }
 
@@ -80,6 +91,9 @@ impl ContractRegistry {
         }
         caller.require_auth();
         env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         Ok(())
     }
 
@@ -119,6 +133,9 @@ impl ContractRegistry {
         env.storage()
             .instance()
             .set(&DataKey::RegistrationCount, &count);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         Ok(())
     }
 
@@ -134,6 +151,9 @@ impl ContractRegistry {
         if !env.storage().persistent().has(&key) {
             return Err(Error::ContractNotFound);
         }
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         Ok(())
     }
 
@@ -164,6 +184,9 @@ impl ContractRegistry {
         env.storage()
             .instance()
             .set(&DataKey::RegistrationCount, &count);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         Ok(())
     }
 
@@ -197,6 +220,9 @@ impl ContractRegistry {
         }
         events.push_back(event_name);
         env.storage().instance().set(&DataKey::Events, &events);
+        env.storage()
+            .instance()
+            .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
         Ok(())
     }
 

--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -135,4 +135,8 @@ pub enum Error {
     /// Players must be valid, controlled addresses. Matches created with zero addresses
     /// would result in payout funds being sent to uncontrolled addresses.
     InvalidAddress = 27,
+
+    /// [E028] `override_result` was called after the dispute window expired.
+    /// The pending result can no longer be overridden and should instead be finalized.
+    DisputeWindowExpired = 28,
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -481,7 +481,7 @@ impl EscrowContract {
             player2_deposited: false,
             created_ledger: env.ledger().sequence(),
             activated_ledger: None,
-            pending_result_ledger: 0,
+            pending_result_ledger: None,
             pending_winner: OptionalWinner::None,
             cancelled_ledger: None,
             completed_ledger: None,
@@ -745,10 +745,13 @@ impl EscrowContract {
 
         // Ensure the dispute window has not yet expired; after expiry the result
         // is final and must be processed via finalize_result.
+        let prl = m
+            .pending_result_ledger
+            .ok_or(Error::InvalidState)?;
         let current = env.ledger().sequence();
         let dispute_window = Self::get_dispute_window_ledgers(&env);
-        if current > m.pending_result_ledger + dispute_window {
-            return Err(Error::DisputeWindowActive);
+        if current > prl + dispute_window {
+            return Err(Error::DisputeWindowExpired);
         }
 
         let old_winner = m.pending_winner.clone();
@@ -824,9 +827,12 @@ impl EscrowContract {
             return Err(Error::InvalidState);
         }
 
+        let prl = m
+            .pending_result_ledger
+            .ok_or(Error::InvalidState)?;
         let current = env.ledger().sequence();
         let dispute_window = Self::get_dispute_window_ledgers(&env);
-        if current <= m.pending_result_ledger + dispute_window {
+        if current <= prl + dispute_window {
             return Err(Error::DisputeWindowActive);
         }
 
@@ -923,7 +929,7 @@ impl EscrowContract {
         let activated = m.activated_ledger.ok_or(Error::InvalidState)?;
         let current = env.ledger().sequence();
         let timeout = Self::get_timeout_ledgers(&env);
-        if current <= m.activated_ledger + timeout {
+        if current <= activated + timeout {
             // Timeout period has not elapsed yet — reject with MatchTimedOut reused
             // as "too early". We return MatchTimedOut here to keep error codes minimal;
             // callers should interpret it as "timeout not yet reached".
@@ -939,6 +945,7 @@ impl EscrowContract {
 
         // STATE TRANSITION: Active → Cancelled (via timeout)
         m.state = MatchState::Cancelled;
+        m.cancelled_ledger = Some(env.ledger().sequence());
         env.storage()
             .persistent()
             .set(&DataKey::Match(match_id), &m);


### PR DESCRIPTION
## Summary

This PR fixes four high-priority contract issues affecting escrow state handling and contract-registry instance storage lifetime.

### Escrow

#### Safely handle `pending_result_ledger`

`pending_result_ledger` is an optional ledger value and now correctly represents a match with no submitted result as `None`.

`finalize_result` explicitly unwraps the pending-result ledger before performing dispute-window arithmetic and returns `Error::InvalidState` when no result has been submitted.

The corresponding `override_result` dispute-window calculation also safely unwraps the optional ledger value before arithmetic.

#### Distinguish an expired dispute window

Added `Error::DisputeWindowExpired` as error code `28` without changing any existing error discriminants.

`override_result` now returns `DisputeWindowExpired` when an override is attempted after the dispute window has elapsed, rather than incorrectly returning `DisputeWindowActive`.

`DisputeWindowActive` remains used when `finalize_result` is attempted while the dispute window is still open.

#### Record timeout cancellation ledger

`claim_timeout` now sets:

`cancelled_ledger = Some(env.ledger().sequence())`

when transitioning an active match to `MatchState::Cancelled`.

It also uses the already-unwrapped `activated` ledger when performing timeout arithmetic.

### Contract Registry

Added instance-storage TTL management to all successful mutating registry entry points:

* `initialize`
* `pause`
* `unpause`
* `register_contract`
* `update_contract`
* `deregister_contract`
* `submit_event`

Each successful mutation now extends the contract instance TTL, preventing registry instance state from silently expiring.

## Validation

* `git diff --check` passes
* changes are limited to the assigned escrow and contract-registry implementation files
* verified 7 registry instance TTL extension calls
* no new dependencies introduced

Repository-wide contract tests are currently blocked by pre-existing unrelated compilation errors in the upstream baseline. Those issues were intentionally left unchanged.

Closes #1503
Closes #1505
Closes #1508
Closes #1510